### PR TITLE
Adding loaders and db integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,9 @@
   "ocaml.sandbox": {
     "kind": "opam",
     "switch": "4.14.0"
-  }
+  },
+  "[rescript]": {
+    "editor.defaultFormatter": "chenglou92.rescript-vscode",
+    "editor.formatOnSave": true
+  },
 }

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@rescript/core": "^0.2.0",
+        "dataloader": "^2.2.2",
         "graphql": "^15.8.0",
         "graphql-yoga": "^3.8.0",
         "rescript": "10.1.4"
@@ -352,6 +353,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g=="
     },
     "node_modules/dset": {
       "version": "3.1.2",
@@ -1132,6 +1138,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "dataloader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g=="
     },
     "dset": {
       "version": "3.1.2",

--- a/tests/package.json
+++ b/tests/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@rescript/core": "^0.2.0",
+    "dataloader": "^2.2.2",
     "graphql": "^15.8.0",
     "graphql-yoga": "^3.8.0",
     "rescript": "10.1.4"

--- a/tests/src/DB.res
+++ b/tests/src/DB.res
@@ -1,0 +1,50 @@
+open Belt
+
+module User = {
+  type t = {
+    id: string,
+    name: string,
+    age: int,
+    lastAge: option<int>, // nullable column
+  }
+
+  let rows = [{id: "1", name: "User 1", age: 35, lastAge: None}]
+
+  let find = async id => {
+    rows->Array.getBy(row => row.id == id)
+  }
+
+  let findMany = async ids => {
+    await ids->Array.map(find)->Js.Promise2.all
+  }
+}
+
+module Group = {
+  type t = {
+    id: int,
+    name: string,
+  }
+
+  let rows = [{id: 1, name: "Group A"}]
+
+  let find = async id => {
+    rows->Array.getBy(row => row.id == id)
+  }
+
+  let findMany = async ids => {
+    await ids->Array.map(find)->Js.Promise2.all
+  }
+}
+
+module Membership = {
+  type t = {
+    memberId: string,
+    groupId: int,
+  }
+
+  let rows = [{memberId: "1", groupId: 1}]
+
+  let findGroupMembers = async groupId => {
+    rows->Array.keep(row => row.groupId == groupId)->Array.map(row => row.memberId)
+  }
+}

--- a/tests/src/DataLoader.res
+++ b/tests/src/DataLoader.res
@@ -1,0 +1,16 @@
+module type Config = {
+  type t
+  type key
+}
+
+module Make = (Config: Config) => {
+  type t
+  type key = Config.key
+  type value = Config.t
+
+  type batchFn = array<key> => promise<array<value>>
+
+  @module @new external createLoader: batchFn => t = "dataloader"
+  @send external load: (t, key) => promise<value> = "load"
+  @send external loadMany: (t, array<key>) => promise<array<value>> = "loadMany"
+}

--- a/tests/src/ResGraphContext.res
+++ b/tests/src/ResGraphContext.res
@@ -1,1 +1,10 @@
-type context = {currentUserId: option<string>, loadCurrentUser: unit => promise<option<User.user>>}
+module UserLoader = DataLoader.Make({
+  type t = option<DB.User.t>
+  type key = string
+})
+
+type context = {
+  currentUserId: option<string>,
+  loadCurrentUser: unit => promise<option<DB.User.t>>,
+  userLoader: UserLoader.t,
+}

--- a/tests/src/TestApp.res
+++ b/tests/src/TestApp.res
@@ -20,14 +20,14 @@ open Yoga
 let yoga = createYoga({
   schema: ResGraphSchema.schema,
   context: async ({request}) => {
+    open ResGraphContext
     ignore(request)
+    let currentUserId = "1"
+    let userLoader = UserLoader.createLoader(DB.User.findMany)
     {
-      ResGraphContext.currentUserId: Some("123"),
-      loadCurrentUser: async () => Some({
-        User.name: "TestUser",
-        age: 35,
-        lastAge: None,
-      }),
+      currentUserId: Some(currentUserId),
+      loadCurrentUser: () => userLoader->UserLoader.load(currentUserId),
+      userLoader,
     }
   },
 })


### PR DESCRIPTION
I added a `DB` module to simulate a more realistic env. It assumes a typical RDB table source. And injected an integrated dataloader through the context.

I made intentional mismatches between DB types and application types in this example. I'd expect something to break, but it doesn't, and it works well somehow without modifying resolvers.

Some questions that arise here:

- In what level should db types be handled? in loaders? or in resolvers?
- When I implicitly return the db type from the resolver, why does it still work instead of breaking? (Even though there are no attributes there) Should we additionally check for collisions on return types?
- dataloader's interface expects the batchFn throws `Error`. We can explicitly use `option` or `result` for values, but I think it's a bit inconvenient. Do we need a ReScript version of dataloader instead of binding?