### PR TITLE
Support unqualified ReScript nullable types

### DIFF
--- a/src/ml/GenerateSchema.ml
+++ b/src/ml/GenerateSchema.ml
@@ -95,6 +95,15 @@ let rec findGraphQLType ~(env : SharedTypes.QueryEnv.t)
     | _ -> t
   in
   let typ = findTyp typ in
+  let isRescriptNullablePath path =
+    match pathIdentToList path |> List.rev with
+    | "t" :: ("Nullable" | "Null" | "Stdlib__Nullable" | "Stdlib__Null") :: _
+    | ("nullable" | "null")
+      :: ("Primitive_js_extern" | "Stdlib__Primitive_js_extern")
+      :: _ ->
+      true
+    | _ -> false
+  in
   if isSubscription then (
     let isAsyncIterablePath path =
       match pathIdentToList path |> List.rev with
@@ -171,7 +180,7 @@ let rec findGraphQLType ~(env : SharedTypes.QueryEnv.t)
       | ["ResGraph"; "id"] -> Some (Scalar ID)
       | ["ResGraph"; "resolveInfo"] -> Some InjectInfo
       | ["ResGraphContext"; "context"] -> Some InjectContext
-      | ["Js"; "Nullable"; "t"] | ["Js"; "Null"; "t"] -> (
+      | _ when isRescriptNullablePath path -> (
         match typeArgs with
         | [typeArg] -> (
           let inner =

--- a/tests/src/AppNullableInterop.res
+++ b/tests/src/AppNullableInterop.res
@@ -1,0 +1,17 @@
+@gql.type
+type nullableInterop = {
+  @gql.field
+  nullCount: Null.t<int>,
+  @gql.field
+  nullableName: Nullable.t<string>,
+}
+
+@gql.field
+let nullableInterop = (
+  _: Query.query,
+  ~nullCount: Null.t<int>,
+  ~nullableName: Nullable.t<string>,
+) => {
+  nullCount,
+  nullableName,
+}

--- a/tests/src/__generated__/ResGraphSchema.res
+++ b/tests/src/__generated__/ResGraphSchema.res
@@ -72,6 +72,8 @@ let t_LabelledBeta: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
 let get_LabelledBeta = () => t_LabelledBeta.contents
 let t_Mutation: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
 let get_Mutation = () => t_Mutation.contents
+let t_NullableInterop: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
+let get_NullableInterop = () => t_NullableInterop.contents
 let t_PageInfo: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
 let get_PageInfo = () => t_PageInfo.contents
 let t_Query: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
@@ -366,6 +368,32 @@ t_Mutation.contents = GraphQLObjectType.make({
       },
     }->makeFields,
 })
+t_NullableInterop.contents = GraphQLObjectType.make({
+  name: "NullableInterop",
+  description: ?None,
+  interfaces: [],
+  fields: () =>
+    {
+      "nullCount": {
+        typ: Scalars.int->Scalars.toGraphQLType,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["nullCount"]
+        }),
+      },
+      "nullableName": {
+        typ: Scalars.string->Scalars.toGraphQLType,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["nullableName"]
+        }),
+      },
+    }->makeFields,
+})
 t_PageInfo.contents = GraphQLObjectType.make({
   name: "PageInfo",
   description: "Information about pagination in a connection.",
@@ -478,6 +506,23 @@ t_Query.contents = GraphQLObjectType.make({
         resolve: makeResolveFn((src, args, ctx, info) => {
           let src = typeUnwrapper(src)
           NodeInterfaceResolver.nodes(src, ~ctx, ~ids=args["ids"])
+        }),
+      },
+      "nullableInterop": {
+        typ: get_NullableInterop()->GraphQLObjectType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        args: {
+          "nullCount": {typ: Scalars.int->Scalars.toGraphQLType},
+          "nullableName": {typ: Scalars.string->Scalars.toGraphQLType},
+        }->makeArgs,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppNullableInterop.nullableInterop(
+            src,
+            ~nullCount=args["nullCount"],
+            ~nullableName=args["nullableName"],
+          )
         }),
       },
       "userConnection": {
@@ -981,6 +1026,7 @@ let schema = GraphQLSchemaType.make({
     get_Query()->GraphQLObjectType.toGraphQLType,
     get_FunctionFieldRegression()->GraphQLObjectType.toGraphQLType,
     get_LabelledBeta()->GraphQLObjectType.toGraphQLType,
+    get_NullableInterop()->GraphQLObjectType.toGraphQLType,
     get_ScalarHolder()->GraphQLObjectType.toGraphQLType,
     get_StringConnection()->GraphQLObjectType.toGraphQLType,
     get_PageInfo()->GraphQLObjectType.toGraphQLType,

--- a/tests/src/__generated__/schema.graphql
+++ b/tests/src/__generated__/schema.graphql
@@ -98,6 +98,11 @@ type Mutation {
   updateThing(thingId: ID!, input: UpdateThingInput!): Thing
 }
 
+type NullableInterop {
+  nullCount: Int
+  nullableName: String
+}
+
 
 """Information about pagination in a connection."""
 type PageInfo {
@@ -123,6 +128,7 @@ type Query {
   """Fetches an object given its ID."""
   node(id: ID!): Node
   functionFieldRegression: FunctionFieldRegression!
+  nullableInterop(nullCount: Int, nullableName: String): NullableInterop!
   getLabelled: LabelledAlpha!
   getScalarHolder: ScalarHolder!
   nestedConnection: StringConnection!


### PR DESCRIPTION
## Summary
- recognize unqualified ReScript 12 Null.t and Nullable.t paths as GraphQL nullable values
- keep generated resolver bridges passing raw nullable values instead of converting to option
- add a regression schema field using unqualified Null.t/Nullable.t in object fields and resolver args

## Validation
- npm run build
- make build-resgraph-binary
- make -C tests test