### PR TITLE
Review resgraph 1.1.3 release diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resgraph",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Build GraphQL servers in ReScript.",
   "main": "index.js",
   "scripts": {

--- a/src/ml/GenerateSchema.ml
+++ b/src/ml/GenerateSchema.ml
@@ -96,11 +96,17 @@ let rec findGraphQLType ~(env : SharedTypes.QueryEnv.t)
   in
   let typ = findTyp typ in
   let isRescriptNullablePath path =
-    match pathIdentToList path |> List.rev with
-    | "t" :: ("Nullable" | "Null" | "Stdlib__Nullable" | "Stdlib__Null") :: _
-    | ("nullable" | "null")
-      :: ("Primitive_js_extern" | "Stdlib__Primitive_js_extern")
-      :: _ ->
+    match pathIdentToList path with
+    | ["Nullable"; "t"]
+    | ["Null"; "t"]
+    | ["Stdlib"; "Nullable"; "t"]
+    | ["Stdlib"; "Null"; "t"]
+    | ["Js"; "Nullable"; "t"]
+    | ["Js"; "Null"; "t"]
+    | ["Stdlib__Nullable"; "t"]
+    | ["Stdlib__Null"; "t"]
+    | ["Primitive_js_extern"; ("nullable" | "null")]
+    | ["Stdlib__Primitive_js_extern"; ("nullable" | "null")] ->
       true
     | _ -> false
   in

--- a/tests/src/AppUserDefinedNullable.res
+++ b/tests/src/AppUserDefinedNullable.res
@@ -1,0 +1,14 @@
+module MyDomain = {
+  module Nullable = {
+    @gql.type
+    type t = {
+      @gql.field
+      value: string,
+    }
+  }
+}
+
+@gql.field
+let userDefinedNullable = (_: Query.query): MyDomain.Nullable.t => {
+  value: "user-defined nullable module",
+}

--- a/tests/src/__generated__/ResGraphSchema.res
+++ b/tests/src/__generated__/ResGraphSchema.res
@@ -88,6 +88,8 @@ let t_StringEdge: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
 let get_StringEdge = () => t_StringEdge.contents
 let t_Subscription: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
 let get_Subscription = () => t_Subscription.contents
+let t_T: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
+let get_T = () => t_T.contents
 let t_Thing: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
 let get_Thing = () => t_Thing.contents
 let t_User: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
@@ -542,6 +544,15 @@ t_Query.contents = GraphQLObjectType.make({
           )
         }),
       },
+      "userDefinedNullable": {
+        typ: get_T()->GraphQLObjectType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppUserDefinedNullable.userDefinedNullable(src)
+        }),
+      },
     }->makeFields,
 })
 t_Res12Record.contents = GraphQLObjectType.make({
@@ -655,6 +666,23 @@ t_Subscription.contents = GraphQLObjectType.make({
         subscribe: makeResolveFn((src, args, ctx, info) => {
           let src = typeUnwrapper(src)
           AppSubscription.latestMessage(src, ~ctx)
+        }),
+      },
+    }->makeFields,
+})
+t_T.contents = GraphQLObjectType.make({
+  name: "T",
+  description: ?None,
+  interfaces: [],
+  fields: () =>
+    {
+      "value": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["value"]
         }),
       },
     }->makeFields,
@@ -1036,6 +1064,7 @@ let schema = GraphQLSchemaType.make({
     get_UserEdge()->GraphQLObjectType.toGraphQLType,
     get_User()->GraphQLObjectType.toGraphQLType,
     get_StringEdge()->GraphQLObjectType.toGraphQLType,
+    get_T()->GraphQLObjectType.toGraphQLType,
     get_Mutation()->GraphQLObjectType.toGraphQLType,
     get_Res12Record()->GraphQLObjectType.toGraphQLType,
     get_Thing()->GraphQLObjectType.toGraphQLType,

--- a/tests/src/__generated__/schema.graphql
+++ b/tests/src/__generated__/schema.graphql
@@ -128,6 +128,7 @@ type Query {
   """Fetches an object given its ID."""
   node(id: ID!): Node
   functionFieldRegression: FunctionFieldRegression!
+  userDefinedNullable: T!
   nullableInterop(nullCount: Int, nullableName: String): NullableInterop!
   getLabelled: LabelledAlpha!
   getScalarHolder: ScalarHolder!
@@ -162,6 +163,10 @@ type StringEdge {
 
 type Subscription {
   latestMessage: String!
+}
+
+type T {
+  value: String!
 }
 
 type Thing implements Node {


### PR DESCRIPTION
After-the-fact review gate for the already-published resgraph@1.1.3 patch release. This PR compares the exact v1.1.2 release commit against the v1.1.3 release commit.\n\nContext:\n- Fixes over-broad nullable path matching from PR #39.\n- Adds regression coverage for user-defined nested Nullable.t modules.\n- Bumps package version to 1.1.3.\n\nLocal verification before release:\n- make test\n- npm run build\n- npm pack --dry-run --json\n\nRelease verification:\n- v1.1.3 tag CI passed, including macos-15-intel and package publish.