### PR TITLE
[codex] Support @as for reserved record fields

### DIFF
--- a/src/ml/GenerateSchema.ml
+++ b/src/ml/GenerateSchema.ml
@@ -782,7 +782,7 @@ and inputObjectFieldsOfRecordFields ~objectTypeName ~env ~debug ~schemaState
     ~(full : SharedTypes.full) (fields : SharedTypes.field list) =
   fields
   |> List.filter_map (fun (field : SharedTypes.field) ->
-      let name = field.fname.txt in
+      let name = nameFromAttribute field.attributes ~default:field.fname.txt in
       match
         findGraphQLType field.typ ~debug ~loc:field.fname.loc ~full ~env
           ~schemaState
@@ -992,11 +992,11 @@ and objectTypeFieldsOfRecordFields ~objectTypeName ~env ~schemaState ~debug
       | Some attr -> Some (field, attr))
   |> List.filter_map (fun ((field : SharedTypes.field), _attr) ->
       let fieldType = field.typ in
+      let name = nameFromAttribute field.attributes ~default:field.fname.txt in
       let typ =
         findGraphQLType fieldType ~debug ~loc:field.fname.loc ~full ~env
           ~schemaState
-          ~typeContext:
-            (ObjectField {objectTypeName; fieldName = field.fname.txt})
+          ~typeContext:(ObjectField {objectTypeName; fieldName = name})
       in
       match typ with
       | None ->
@@ -1017,7 +1017,6 @@ and objectTypeFieldsOfRecordFields ~objectTypeName ~env ~schemaState ~debug
                };
         None
       | Some typ ->
-        let name = field.fname.txt in
         Some
           {
             name;
@@ -1037,11 +1036,11 @@ and objectTypeFieldsOfInlineRecordFields ~objectTypeName ~env ~schemaState
   fields
   |> List.filter_map (fun (field : SharedTypes.field) ->
       let fieldType = field.typ in
+      let name = nameFromAttribute field.attributes ~default:field.fname.txt in
       let typ =
         findGraphQLType fieldType ~debug ~loc:field.fname.loc ~full ~env
           ~schemaState
-          ~typeContext:
-            (ObjectField {objectTypeName; fieldName = field.fname.txt})
+          ~typeContext:(ObjectField {objectTypeName; fieldName = name})
       in
       match typ with
       | None ->
@@ -1062,7 +1061,6 @@ and objectTypeFieldsOfInlineRecordFields ~objectTypeName ~env ~schemaState
                };
         None
       | Some typ ->
-        let name = field.fname.txt in
         Some
           {
             name;

--- a/src/ml/GenerateSchemaValidation.ml
+++ b/src/ml/GenerateSchemaValidation.ml
@@ -37,7 +37,31 @@ let validateName ~name ~(typeLocation : typeLocation)
                    name;
              }
 
-let validateFields ~schemaState (fields : gqlField list) =
+let validateFieldNameUniqueness ~schemaState ~(parentTypeName : string)
+    (fields : gqlField list) =
+  let seen = Hashtbl.create (List.length fields) in
+  fields
+  |> List.iter (fun (field : gqlField) ->
+      match Hashtbl.find_opt seen field.name with
+      | None -> Hashtbl.add seen field.name field
+      | Some firstField ->
+        schemaState
+        |> addDiagnostic
+             ~diagnostic:
+               {
+                 loc = field.loc;
+                 fileUri = field.fileUri;
+                 message =
+                   Printf.sprintf
+                     "Field `%s` appears more than once on GraphQL type `%s`. \
+                      Rename one of the fields or change its @as attribute. \
+                      The first field was declared in %s."
+                     field.name parentTypeName firstField.fileName;
+               })
+
+let validateFields ~schemaState ~(parentTypeName : string)
+    (fields : gqlField list) =
+  validateFieldNameUniqueness ~schemaState ~parentTypeName fields;
   fields
   |> List.iter (fun (f : gqlField) ->
       validateName ~name:f.name
@@ -69,16 +93,11 @@ let validateSchema (schemaState : schemaState) =
 
   schemaState.types
   |> Hashtbl.iter (fun _name (typ : gqlObjectType) ->
-      match typ.typeLocation with
-      | Some _typeLocation -> validateFields ~schemaState typ.fields
-      | None -> ());
+      validateFields ~schemaState ~parentTypeName:typ.displayName typ.fields);
 
   schemaState.inputObjects
   |> Hashtbl.iter (fun _name (typ : gqlInputObjectType) ->
-      (* A lot has already been validated on adding the type itself. *)
-      match typ.typeLocation with
-      | Some _typeLocation -> validateFields ~schemaState typ.fields
-      | None -> ());
+      validateFields ~schemaState ~parentTypeName:typ.displayName typ.fields);
 
   schemaState.enums
   |> Hashtbl.iter (fun _name (typ : gqlEnum) ->
@@ -96,4 +115,4 @@ let validateSchema (schemaState : schemaState) =
   |> Hashtbl.iter (fun _name (typ : gqlInterface) ->
       (* Subtype rules etc for interface fields are a bit complicated, so we
             let graphql-js do it at runtime instead. *)
-      validateFields ~schemaState typ.fields)
+      validateFields ~schemaState ~parentTypeName:typ.displayName typ.fields)

--- a/tests/runtime-interface-returns.mjs
+++ b/tests/runtime-interface-returns.mjs
@@ -101,4 +101,44 @@ assert.match(
   /Interface Labelled resolveType expected a tagged value from Interface_labelled\.Resolver\.t/,
 );
 
-console.log("runtime interface return regressions passed");
+const reservedWords = await run(`
+  query ReservedWords {
+    reservedWordRecord {
+      constraint
+      external
+      include
+      let
+      module
+      open
+      switch
+      type
+    }
+  }
+`);
+
+assert.equal(reservedWords.errors, undefined);
+assert.deepEqual(plain(reservedWords.data), {
+  reservedWordRecord: {
+    constraint: "constraint",
+    external: "external",
+    include: "include",
+    let: "let",
+    module: "module",
+    open: "open",
+    switch: "switch",
+    type: "type",
+  },
+});
+
+const reservedInput = await run(`
+  query ReservedInput {
+    reservedWordInputEcho(input: {constraint: "input constraint", type: "input type"})
+  }
+`);
+
+assert.equal(reservedInput.errors, undefined);
+assert.deepEqual(plain(reservedInput.data), {
+  reservedWordInputEcho: "input constraint:input type",
+});
+
+console.log("runtime regressions passed");

--- a/tests/src/AppReScript12.res
+++ b/tests/src/AppReScript12.res
@@ -5,8 +5,7 @@ type res12Record = {
   @gql.field
   withDoc: string,
   /** Deprecated attribute should survive too. */
-  @deprecated("old field")
-  @gql.field
+  @deprecated("old field") @gql.field
   oldField: int,
 }
 
@@ -18,3 +17,48 @@ type res12Input =
       payload: string,
     })
   | Empty
+
+/** Reserved ReScript field names can be exposed as GraphQL names. */
+@gql.type
+type reservedWordRecord = {
+  @as("constraint") @gql.field
+  constraint_: string,
+  @as("external") @gql.field
+  external_: string,
+  @as("include") @gql.field
+  include_: string,
+  @as("let") @gql.field
+  let_: string,
+  @as("module") @gql.field
+  module_: string,
+  @as("open") @gql.field
+  open_: string,
+  @as("switch") @gql.field
+  switch_: string,
+  @as("type") @gql.field
+  type_: string,
+}
+
+@gql.inputObject
+type reservedWordInput = {
+  @as("constraint")
+  constraint_: string,
+  @as("type")
+  type_: string,
+}
+
+@gql.field
+let reservedWordRecord = (_: Query.query): reservedWordRecord => {
+  constraint_: "constraint",
+  external_: "external",
+  include_: "include",
+  let_: "let",
+  module_: "module",
+  open_: "open",
+  switch_: "switch",
+  type_: "type",
+}
+
+@gql.field
+let reservedWordInputEcho = (_: Query.query, ~input: reservedWordInput) =>
+  input.constraint_ ++ ":" ++ input.type_

--- a/tests/src/__generated__/ResGraphSchema.res
+++ b/tests/src/__generated__/ResGraphSchema.res
@@ -123,6 +123,8 @@ let t_Query: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
 let get_Query = () => t_Query.contents
 let t_Res12Record: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
 let get_Res12Record = () => t_Res12Record.contents
+let t_ReservedWordRecord: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
+let get_ReservedWordRecord = () => t_ReservedWordRecord.contents
 let t_ScalarHolder: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
 let get_ScalarHolder = () => t_ScalarHolder.contents
 let t_StringConnection: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
@@ -173,10 +175,14 @@ let inputUnion_UpdatableString_conversionInstructions = []
 let input_Res12InputInline: ref<GraphQLInputObjectType.t> = Obj.magic({"contents": null})
 let get_Res12InputInline = () => input_Res12InputInline.contents
 let input_Res12InputInline_conversionInstructions = []
+let input_ReservedWordInput: ref<GraphQLInputObjectType.t> = Obj.magic({"contents": null})
+let get_ReservedWordInput = () => input_ReservedWordInput.contents
+let input_ReservedWordInput_conversionInstructions = []
 let input_UpdateThingInput: ref<GraphQLInputObjectType.t> = Obj.magic({"contents": null})
 let get_UpdateThingInput = () => input_UpdateThingInput.contents
 let input_UpdateThingInput_conversionInstructions = []
 input_Res12InputInline_conversionInstructions->Array.pushMany([])
+input_ReservedWordInput_conversionInstructions->Array.pushMany([])
 input_UpdateThingInput_conversionInstructions->Array.pushMany([
   (
     "name",
@@ -623,6 +629,32 @@ t_Query.contents = GraphQLObjectType.make({
           )
         }),
       },
+      "reservedWordInputEcho": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        args: {
+          "input": {typ: get_ReservedWordInput()->GraphQLInputObjectType.toGraphQLType->nonNull},
+        }->makeArgs,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppReScript12.reservedWordInputEcho(
+            src,
+            ~input=args["input"]->applyConversionToInputObject(
+              input_ReservedWordInput_conversionInstructions,
+            ),
+          )
+        }),
+      },
+      "reservedWordRecord": {
+        typ: get_ReservedWordRecord()->GraphQLObjectType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppReScript12.reservedWordRecord(src)
+        }),
+      },
       "userConnection": {
         typ: get_UserConnection()->GraphQLObjectType.toGraphQLType->nonNull,
         description: ?None,
@@ -673,6 +705,86 @@ t_Res12Record.contents = GraphQLObjectType.make({
         resolve: makeResolveFn((src, _args, _ctx, _info) => {
           let src = typeUnwrapper(src)
           src["withDoc"]
+        }),
+      },
+    }->makeFields,
+})
+t_ReservedWordRecord.contents = GraphQLObjectType.make({
+  name: "ReservedWordRecord",
+  description: "Reserved ReScript field names can be exposed as GraphQL names.",
+  interfaces: [],
+  fields: () =>
+    {
+      "constraint": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["constraint"]
+        }),
+      },
+      "external": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["external"]
+        }),
+      },
+      "include": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["include"]
+        }),
+      },
+      "let": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["let"]
+        }),
+      },
+      "module": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["module"]
+        }),
+      },
+      "open": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["open"]
+        }),
+      },
+      "switch": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["switch"]
+        }),
+      },
+      "type": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["type"]
         }),
       },
     }->makeFields,
@@ -955,6 +1067,23 @@ input_Res12InputInline.contents = GraphQLInputObjectType.make({
       },
     }->makeFields,
 })
+input_ReservedWordInput.contents = GraphQLInputObjectType.make({
+  name: "ReservedWordInput",
+  description: ?None,
+  fields: () =>
+    {
+      "constraint": {
+        GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+      "type": {
+        GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+    }->makeFields,
+})
 input_UpdateThingInput.contents = GraphQLInputObjectType.make({
   name: "UpdateThingInput",
   description: ?None,
@@ -1194,6 +1323,7 @@ let schema = GraphQLSchemaType.make({
     get_PageInfo()->GraphQLObjectType.toGraphQLType,
     get_Query()->GraphQLObjectType.toGraphQLType,
     get_Res12Record()->GraphQLObjectType.toGraphQLType,
+    get_ReservedWordRecord()->GraphQLObjectType.toGraphQLType,
     get_ScalarHolder()->GraphQLObjectType.toGraphQLType,
     get_StringConnection()->GraphQLObjectType.toGraphQLType,
     get_StringEdge()->GraphQLObjectType.toGraphQLType,
@@ -1215,6 +1345,7 @@ let schema = GraphQLSchemaType.make({
     get_UpdatableNullableString()->GraphQLInputObjectType.toGraphQLType,
     get_UpdatableString()->GraphQLInputObjectType.toGraphQLType,
     get_Res12InputInline()->GraphQLInputObjectType.toGraphQLType,
+    get_ReservedWordInput()->GraphQLInputObjectType.toGraphQLType,
     get_UpdateThingInput()->GraphQLInputObjectType.toGraphQLType,
   ],
 })

--- a/tests/src/__generated__/schema.graphql
+++ b/tests/src/__generated__/schema.graphql
@@ -8,6 +8,11 @@ input Res12InputInline {
   payload: String!
 }
 
+input ReservedWordInput {
+  constraint: String!
+  type: String!
+}
+
 input UpdateThingInput {
   name: UpdatableString!
   age: UpdatableInt!
@@ -133,6 +138,8 @@ type Query {
   node(id: ID!): Node
   functionFieldRegression: FunctionFieldRegression!
   userDefinedNullable: T!
+  reservedWordInputEcho(input: ReservedWordInput!): String!
+  reservedWordRecord: ReservedWordRecord!
   nullableInterop(nullCount: Int, nullableName: String): NullableInterop!
   getLabelled: LabelledAlpha!
   brokenLabelledWrapper: LabelledWrapper!
@@ -153,6 +160,19 @@ type Res12Record {
 
   """Deprecated attribute should survive too."""
   oldField: Int! @deprecated(reason: "old field")
+}
+
+
+"""Reserved ReScript field names can be exposed as GraphQL names."""
+type ReservedWordRecord {
+  constraint: String!
+  external: String!
+  include: String!
+  let: String!
+  module: String!
+  open: String!
+  switch: String!
+  type: String!
 }
 
 type ScalarHolder {


### PR DESCRIPTION
## Summary

This updates schema extraction so record-backed GraphQL fields can use `@as("...")` for the emitted GraphQL field name. That makes reserved ReScript names usable as safe ReScript identifiers while still exposing the intended GraphQL names.

The generated property resolver now reads the emitted runtime field name, matching ReScript's `@as` output for records.

## Validation

- `make build-resgraph-binary && make -C tests test`

## Notes

This covers object record fields and input object fields. Resolver function field aliases and escaped resolver argument labels remain separate follow-up work.