### PR TITLE
[codex] Add explicit interface implements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.1.6
 
+- Add repeatable `@gql.implements("InterfaceName")` for declaring object and interface implementations without spreading fields into the ReScript record.
+- Validate GraphQL interface implementation parity during schema generation, including missing interfaces, missing fields, output field type compatibility, required field arguments, argument type mismatches, and extra required arguments.
 - Support escaped resolver argument labels for reserved ReScript names, allowing GraphQL arguments like `constraint` while using ReScript-safe local bindings.
 - Document reserved ReScript name handling across object fields, interface fields, input objects, unions, input unions and resolver arguments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # ResGraph Changelog
 
-## 1.1.6
+## 1.2.0
 
 - Add repeatable `@gql.implements("InterfaceName")` for declaring object and interface implementations without spreading fields into the ReScript record.
 - Validate GraphQL interface implementation parity during schema generation, including missing interfaces, missing fields, output field type compatibility, required field arguments, argument type mismatches, and extra required arguments.
+
+## 1.1.6
+
 - Support escaped resolver argument labels for reserved ReScript names, allowing GraphQL arguments like `constraint` while using ReScript-safe local bindings.
 - Document reserved ReScript name handling across object fields, interface fields, input objects, unions, input unions and resolver arguments.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,24 @@ enum TextFormat {
 
 [Check out the docs on getting started](https://zth.github.io/resgraph/docs/getting-started).
 
+Interfaces can be implemented by spreading the interface record into the
+implementing record, or explicitly with repeatable `@gql.implements(...)`
+attributes when the implementing type declares the shared fields itself:
+
+```rescript
+@gql.interface
+type hasName = {
+  @gql.field name: string,
+}
+
+@gql.implements("HasName")
+@gql.type
+type user = {
+  @gql.field name: string,
+  @gql.field age: int,
+}
+```
+
 ## Introduction
 
 ResGraph lets you build _implementation first_ GraphQL servers, where your types and code is the source of truth for the schema.

--- a/docs/docs/interfaces.md
+++ b/docs/docs/interfaces.md
@@ -68,6 +68,44 @@ type User implements HasName {
 }
 ```
 
+You can also implement interfaces explicitly with `@gql.implements("InterfaceName")`.
+This is useful when the implementing type already declares the fields itself, or
+when spreading the interface record would not fit the ReScript type shape you
+want.
+
+```rescript
+/** An entity with a name. */
+@gql.interface
+type hasName = {
+  /** The name of the thing. */
+  @gql.field name: string
+}
+
+/** An entity with a stable rank. */
+@gql.interface
+type ranked = {
+  @gql.field rank: int
+}
+
+/** A user in the system. */
+@gql.implements("HasName")
+@gql.implements("Ranked")
+@gql.type
+type user = {
+  @gql.field name: string,
+  @gql.field rank: int,
+  @gql.field age: int
+}
+```
+
+```graphql
+type User implements HasName & Ranked {
+  name: String!
+  rank: Int!
+  age: Int!
+}
+```
+
 ## Exposing fields from the interface
 
 Just like with [fields on object types](object-types#fields), you can expose fields on interfaces either directly via `@gql.field`, or by defining a function with `@gql.field`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resgraph",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "Build GraphQL servers in ReScript.",
   "main": "index.js",
   "scripts": {

--- a/src/ml/GenerateSchema.ml
+++ b/src/ml/GenerateSchema.ml
@@ -226,6 +226,25 @@ let rec findGraphQLType ~(env : SharedTypes.QueryEnv.t)
           let gqlAttribute =
             item.attributes |> extractGqlAttribute ~env ~schemaState
           in
+          let gqlImplementsAttributes =
+            item.attributes |> extractGqlImplementsAttributes ~schemaState ~env
+          in
+          (if List.length gqlImplementsAttributes > 0 then
+             match (gqlAttribute, item) with
+             | Some ObjectType, {kind = Record _}
+             | Some Interface, {kind = Record _} ->
+               ()
+             | _ ->
+               schemaState
+               |> addDiagnostic
+                    ~diagnostic:
+                      {
+                        loc = item.decl.type_loc;
+                        fileUri = env.file.uri;
+                        message =
+                          "`@gql.implements` can only be used on @gql.type or \
+                           @gql.interface records.";
+                      });
           match (gqlAttribute, item) with
           | ( Some ObjectType,
               {
@@ -247,6 +266,7 @@ let rec findGraphQLType ~(env : SharedTypes.QueryEnv.t)
             noticeObjectType id ~displayName ~schemaState ~env
               ?description:
                 (GenerateSchemaUtils.attributesToDocstring attributes)
+              ~explicitInterfaces:gqlImplementsAttributes
               ~makeFields:(fun () ->
                 fields
                 |> objectTypeFieldsOfRecordFields ~objectTypeName:displayName
@@ -290,6 +310,7 @@ let rec findGraphQLType ~(env : SharedTypes.QueryEnv.t)
                   id;
                   displayName;
                   interfaces = [];
+                  explicitInterfaces = gqlImplementsAttributes;
                   fields =
                     objectTypeFieldsOfRecordFields fields
                       ~objectTypeName:displayName ~env ~full ~schemaState ~debug;
@@ -1175,6 +1196,23 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
         let gqlAttribute =
           attributes |> extractGqlAttribute ~schemaState ~env
         in
+        let gqlImplementsAttributes =
+          attributes |> extractGqlImplementsAttributes ~schemaState ~env
+        in
+        (if List.length gqlImplementsAttributes > 0 then
+           match (item.kind, gqlAttribute) with
+           | Type ({kind = Record _}, _), Some (ObjectType | Interface) -> ()
+           | _ ->
+             schemaState
+             |> addDiagnostic
+                  ~diagnostic:
+                    {
+                      loc = item.loc;
+                      fileUri = env.file.uri;
+                      message =
+                        "`@gql.implements` can only be used on @gql.type or \
+                         @gql.interface records.";
+                    });
         match (item.kind, gqlAttribute) with
         | Module {type_ = Structure structure; _}, _ ->
           (* Continue into modules (ignore module aliases etc) *)
@@ -1219,7 +1257,7 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
           let displayName = capitalizeFirstChar item.name in
           noticeObjectType ~env ~loc:decl.type_loc ~schemaState
             ?description:(attributesToDocstring attributes)
-            ~displayName
+            ~displayName ~explicitInterfaces:gqlImplementsAttributes
             ~makeFields:(fun () ->
               objectTypeFieldsOfRecordFields fields ~objectTypeName:displayName
                 ~env ~full ~schemaState ~debug)
@@ -1256,6 +1294,7 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
                     ~objectTypeName:displayName ~env ~full ~schemaState ~debug;
                 description = attributesToDocstring attributes;
                 interfaces = [];
+                explicitInterfaces = gqlImplementsAttributes;
                 typeLocation =
                   findTypeLocation item.name ~env ~schemaState
                     ~loc:decl.type_loc ~expectedType:Interface;

--- a/src/ml/GenerateSchemaTypes.ml
+++ b/src/ml/GenerateSchemaTypes.ml
@@ -50,6 +50,12 @@ type gqlArg = {
 
 type gqlInterfaceIdentifier = {id: string; displayName: string}
 
+type explicitInterfaceImplementation = {
+  interfaceName: string;
+  loc: Location.t;
+  fileUri: Uri.t;
+}
+
 type gqlEnumValue = {
   value: string;
   description: string option;
@@ -119,6 +125,7 @@ type gqlObjectType = {
   typeLocation: typeLocation option;
   syntheticTypeLocation: syntheticTypeLocation option;
   interfaces: string list;
+  explicitInterfaces: explicitInterfaceImplementation list;
 }
 
 type gqlInterface = {
@@ -128,6 +135,7 @@ type gqlInterface = {
   description: string option;
   typeLocation: typeLocationLoc;
   interfaces: string list;
+  explicitInterfaces: explicitInterfaceImplementation list;
 }
 
 type gqlInputObjectType = {

--- a/src/ml/GenerateSchemaUtils.ml
+++ b/src/ml/GenerateSchemaUtils.ml
@@ -31,6 +31,9 @@ let validAttributes =
     ("gql.type", "Indicates that the annotated record is a GraphQL Object Type.");
     ( "gql.interface",
       "Indicates that the annotated record is a GraphQL interface." );
+    ( "gql.implements",
+      "Indicates that the annotated object type or interface implements a \
+       GraphQL interface." );
     ("gql.interfaceResolver", "");
     ("gql.field", "");
     ("gql.enum", "");
@@ -52,6 +55,7 @@ let extractGqlAttribute ~(schemaState : GenerateSchemaTypes.schemaState)
       match String.split_on_char '.' name.txt with
       | ["gql"; "type"] -> Some ObjectType
       | ["gql"; "interface"] -> Some Interface
+      | ["gql"; "implements"] -> None
       | ["gql"; "scalar"] -> Some Scalar
       | ["gql"; "interfaceResolver"] -> (
         match payload with
@@ -103,6 +107,41 @@ let extractGqlAttribute ~(schemaState : GenerateSchemaTypes.schemaState)
                      name.txt;
                };
         None
+      | _ -> None)
+
+let extractGqlImplementsAttributes
+    ~(schemaState : GenerateSchemaTypes.schemaState)
+    ~(env : SharedTypes.QueryEnv.t) (attributes : Parsetree.attributes) =
+  attributes
+  |> List.filter_map (fun ((name, payload) : Parsetree.attribute) ->
+      match String.split_on_char '.' name.txt with
+      | ["gql"; "implements"] -> (
+        match payload with
+        | PStr
+            [
+              {
+                pstr_desc =
+                  Pstr_eval
+                    ( {
+                        pexp_desc =
+                          Pexp_constant (Pconst_string (interfaceName, _));
+                      },
+                      _ );
+              };
+            ] ->
+          Some {interfaceName; loc = name.loc; fileUri = env.file.uri}
+        | _ ->
+          schemaState
+          |> addDiagnostic
+               ~diagnostic:
+                 {
+                   loc = name.loc;
+                   fileUri = env.file.uri;
+                   message =
+                     "`@gql.implements` requires a string literal GraphQL \
+                      interface name.";
+                 };
+          None)
       | _ -> None)
 
 let getFieldAttribute gqlAttribute =
@@ -255,7 +294,8 @@ let uncapitalizeFirstChar s =
   else String.mapi (fun i c -> if i = 0 then Char.lowercase_ascii c else c) s
 
 let noticeObjectType ~env ~loc ~schemaState ~displayName ?syntheticTypeLocation
-    ?description ?(ignoreTypeLocation = false) ~makeFields typeName =
+    ?description ?(ignoreTypeLocation = false) ?(explicitInterfaces = [])
+    ~makeFields typeName =
   if Hashtbl.mem schemaState.types typeName then ()
   else
     (*Printf.printf "noticing %s\n" typeName;*)
@@ -267,6 +307,7 @@ let noticeObjectType ~env ~loc ~schemaState ~displayName ?syntheticTypeLocation
         fields = makeFields ();
         description;
         interfaces = [];
+        explicitInterfaces;
         typeLocation =
           (if ignoreTypeLocation then None
            else
@@ -341,6 +382,7 @@ let addFieldToObjectType ~env ~loc ~field ~schemaState typeName =
         displayName = capitalizeFirstChar typeName;
         fields = [field];
         interfaces = [];
+        explicitInterfaces = [];
         description = field.description;
         typeLocation =
           Some
@@ -361,6 +403,7 @@ let addFieldToInterfaceType ~env ~loc ~field ~schemaState typeName =
         displayName = capitalizeFirstChar typeName;
         fields = [field];
         interfaces = [];
+        explicitInterfaces = [];
         description = field.description;
         typeLocation =
           findTypeLocation ~schemaState typeName ~env ~loc
@@ -597,6 +640,218 @@ let hashtblToListAlphabetically hashtbl =
 let iterHashtblAlphabetically fn hashtbl =
   hashtblToListAlphabetically hashtbl |> List.iter (fun (k, v) -> fn k v)
 
+let findInterfaceByName (schemaState : schemaState) interfaceName =
+  match Hashtbl.find_opt schemaState.interfaces interfaceName with
+  | Some intf -> Some intf
+  | None ->
+    Hashtbl.fold
+      (fun _id (intf : gqlInterface) acc ->
+        match acc with
+        | Some _ -> acc
+        | None -> if intf.displayName = interfaceName then Some intf else None)
+      schemaState.interfaces None
+
+let appendUniqueString values value =
+  if List.mem value values then values else values @ [value]
+
+let appendUniqueStrings values newValues =
+  newValues |> List.fold_left appendUniqueString values
+
+let isResolverField (field : gqlField) =
+  match field.resolverStyle with
+  | Resolver _ -> true
+  | Property _ -> false
+
+let addMissingInterfaceResolverFields ~displayName fields (intf : gqlInterface)
+    =
+  let hasField name =
+    fields |> List.exists (fun (field : gqlField) -> field.name = name)
+  in
+  fields
+  @ (intf.fields
+    |> List.filter (fun (field : gqlField) ->
+        isResolverField field && hasField field.name = false)
+    |> List.map (fun (field : gqlField) ->
+        {field with onType = Some displayName}))
+
+let inheritInterfaceResolverFields (schemaState : schemaState) =
+  schemaState.types |> hashtblToListAlphabetically
+  |> List.iter (fun (_id, (typ : gqlObjectType)) ->
+      let fields =
+        typ.interfaces
+        |> List.fold_left
+             (fun fields intfId ->
+               match Hashtbl.find_opt schemaState.interfaces intfId with
+               | None -> fields
+               | Some intf ->
+                 addMissingInterfaceResolverFields ~displayName:typ.displayName
+                   fields intf)
+             typ.fields
+      in
+      Hashtbl.replace schemaState.types typ.id {typ with fields});
+
+  schemaState.interfaces |> hashtblToListAlphabetically
+  |> List.iter (fun (_id, (typ : gqlInterface)) ->
+      let fields =
+        typ.interfaces
+        |> List.fold_left
+             (fun fields intfId ->
+               match Hashtbl.find_opt schemaState.interfaces intfId with
+               | None -> fields
+               | Some intf ->
+                 addMissingInterfaceResolverFields ~displayName:typ.displayName
+                   fields intf)
+             typ.fields
+      in
+      Hashtbl.replace schemaState.interfaces typ.id {typ with fields})
+
+let implementedById (implementedBy : interfaceImplementedBy) =
+  match implementedBy with
+  | ObjectType typ -> typ.id
+  | Interface intf -> intf.id
+
+let registerInterfaceImplementedBy processedSchema intfId
+    (implementedBy : interfaceImplementedBy) =
+  match Hashtbl.find_opt processedSchema.interfaceImplementedBy intfId with
+  | None ->
+    Hashtbl.add processedSchema.interfaceImplementedBy intfId [implementedBy]
+  | Some existing ->
+    if
+      existing
+      |> List.exists (fun existingImplementedBy ->
+          implementedById existingImplementedBy = implementedById implementedBy)
+    then ()
+    else
+      Hashtbl.replace processedSchema.interfaceImplementedBy intfId
+        (implementedBy :: existing)
+
+let rec collectInterfaceAncestors (schemaState : schemaState) ~visited intfId =
+  if List.mem intfId visited then []
+  else
+    match Hashtbl.find_opt schemaState.interfaces intfId with
+    | None -> []
+    | Some intf ->
+      let visited = intfId :: visited in
+      intf.interfaces
+      |> List.fold_left
+           (fun acc parentInterfaceId ->
+             let acc = appendUniqueString acc parentInterfaceId in
+             appendUniqueStrings acc
+               (collectInterfaceAncestors schemaState ~visited parentInterfaceId))
+           []
+
+let expandInterfaceList schemaState interfaces =
+  interfaces
+  |> List.fold_left
+       (fun acc intfId ->
+         let acc = appendUniqueString acc intfId in
+         appendUniqueStrings acc
+           (collectInterfaceAncestors schemaState ~visited:[] intfId))
+       []
+
+let expandTransitiveInterfaceImplementations schemaState processedSchema =
+  schemaState.types |> hashtblToListAlphabetically
+  |> List.iter (fun (_id, (typ : gqlObjectType)) ->
+      let expandedInterfaces = expandInterfaceList schemaState typ.interfaces in
+      let typ = {typ with interfaces = expandedInterfaces} in
+      Hashtbl.replace schemaState.types typ.id typ;
+      expandedInterfaces
+      |> List.iter (fun intfId ->
+          registerInterfaceImplementedBy processedSchema intfId (ObjectType typ)));
+
+  schemaState.interfaces |> hashtblToListAlphabetically
+  |> List.iter (fun (_id, (typ : gqlInterface)) ->
+      let expandedInterfaces = expandInterfaceList schemaState typ.interfaces in
+      let typ = {typ with interfaces = expandedInterfaces} in
+      Hashtbl.replace schemaState.interfaces typ.id typ;
+      expandedInterfaces
+      |> List.iter (fun intfId ->
+          registerInterfaceImplementedBy processedSchema intfId (Interface typ)))
+
+let uniqueImplementedBy implementedBy =
+  implementedBy
+  |> List.fold_left
+       (fun acc item ->
+         if
+           acc
+           |> List.exists (fun existingItem ->
+               implementedById existingItem = implementedById item)
+         then acc
+         else item :: acc)
+       []
+  |> List.rev
+
+let finalizeConcreteInterfaceImplementations (processedSchema : processedSchema)
+    =
+  let originalImplementations =
+    Hashtbl.copy processedSchema.interfaceImplementedBy
+  in
+  let rec collectConcreteImplementations ~visited intfId =
+    if List.mem intfId visited then []
+    else
+      match Hashtbl.find_opt originalImplementations intfId with
+      | None -> []
+      | Some implementedBy ->
+        implementedBy
+        |> List.fold_left
+             (fun acc (implementedBy : interfaceImplementedBy) ->
+               match implementedBy with
+               | ObjectType _ -> implementedBy :: acc
+               | Interface intf ->
+                 collectConcreteImplementations ~visited:(intfId :: visited)
+                   intf.id
+                 @ acc)
+             []
+        |> uniqueImplementedBy
+  in
+  originalImplementations
+  |> iterHashtblAlphabetically (fun intfId _ ->
+      match collectConcreteImplementations ~visited:[] intfId with
+      | [] -> Hashtbl.remove processedSchema.interfaceImplementedBy intfId
+      | concreteImplementations ->
+        Hashtbl.replace processedSchema.interfaceImplementedBy intfId
+          concreteImplementations)
+
+let typeLocationLocOfObjectType (typ : gqlObjectType) =
+  match typ.typeLocation with
+  | Some (Concrete typeLocation) -> Some typeLocation
+  | Some (Synthetic {fileUri; modulePath; fileName}) ->
+    let loc =
+      match typ.syntheticTypeLocation with
+      | Some {loc} -> loc
+      | None -> Location.none
+    in
+    Some {fileName; fileUri; modulePath; typeName = typ.id; loc}
+  | None -> None
+
+let validateInterfaceImplementations (schemaState : schemaState) =
+  schemaState.types |> hashtblToListAlphabetically
+  |> List.iter (fun (_id, (typ : gqlObjectType)) ->
+      match typeLocationLocOfObjectType typ with
+      | None -> ()
+      | Some typeLocation ->
+        typ.interfaces
+        |> List.iter (fun intfId ->
+            match Hashtbl.find_opt schemaState.interfaces intfId with
+            | None -> ()
+            | Some intf ->
+              GenerateSchemaValidation.validateInterfaceImplementation
+                ~schemaState ~loc:typeLocation.loc ~fileUri:typeLocation.fileUri
+                ~implementingTypeName:typ.displayName
+                ~implementingFields:typ.fields ~interface:intf));
+  schemaState.interfaces |> hashtblToListAlphabetically
+  |> List.iter (fun (_id, (typ : gqlInterface)) ->
+      typ.interfaces
+      |> List.iter (fun intfId ->
+          match Hashtbl.find_opt schemaState.interfaces intfId with
+          | None -> ()
+          | Some intf ->
+            GenerateSchemaValidation.validateInterfaceImplementation
+              ~schemaState ~loc:typ.typeLocation.loc
+              ~fileUri:typ.typeLocation.fileUri
+              ~implementingTypeName:typ.displayName
+              ~implementingFields:typ.fields ~interface:intf))
+
 let processSchema (schemaState : schemaState) =
   let processedSchema = {interfaceImplementedBy = Hashtbl.create 10} in
   let positionsToRead = Hashtbl.create 10 in
@@ -650,7 +905,7 @@ let processSchema (schemaState : schemaState) =
               id = t.id;
               position =
                 (t.typeLocation.loc |> Loc.start, t.typeLocation.loc |> Loc.end_);
-              typ = ObjectType;
+              typ = Interface;
             };
           ]
       | Some existingEntries ->
@@ -659,7 +914,7 @@ let processSchema (schemaState : schemaState) =
              id = t.id;
              position =
                (t.typeLocation.loc |> Loc.start, t.typeLocation.loc |> Loc.end_);
-             typ = ObjectType;
+             typ = Interface;
            }
           :: existingEntries));
 
@@ -713,7 +968,10 @@ let processSchema (schemaState : schemaState) =
                  Hashtbl.replace schemaState.types entry.id
                    {
                      (Hashtbl.find schemaState.types entry.id) with
-                     interfaces = implementsInterfaces;
+                     interfaces =
+                       appendUniqueStrings
+                         (Hashtbl.find schemaState.types entry.id).interfaces
+                         implementsInterfaces;
                    };
 
                  (* Process each interface for this type *)
@@ -743,44 +1001,86 @@ let processSchema (schemaState : schemaState) =
                        };
 
                      (* Map interface as implemented by this type *)
-                     match
-                       Hashtbl.find_opt processedSchema.interfaceImplementedBy
-                         intfId
-                     with
-                     | None ->
-                       Hashtbl.add processedSchema.interfaceImplementedBy intfId
-                         [ObjectType (Hashtbl.find schemaState.types entry.id)]
-                     | Some item ->
-                       Hashtbl.replace processedSchema.interfaceImplementedBy
-                         intfId
-                         (ObjectType (Hashtbl.find schemaState.types entry.id)
-                         :: item))
+                     registerInterfaceImplementedBy processedSchema intfId
+                       (ObjectType (Hashtbl.find schemaState.types entry.id)))
                | Interface ->
                  Hashtbl.replace schemaState.interfaces entry.id
                    {
                      (Hashtbl.find schemaState.interfaces entry.id) with
-                     interfaces = implementsInterfaces;
+                     interfaces =
+                       appendUniqueStrings
+                         (Hashtbl.find schemaState.interfaces entry.id)
+                           .interfaces implementsInterfaces;
                    };
                  implementsInterfaces
                  |> List.iter (fun intfId ->
-                     match
-                       Hashtbl.find_opt processedSchema.interfaceImplementedBy
-                         intfId
-                     with
-                     | None ->
-                       Hashtbl.add processedSchema.interfaceImplementedBy intfId
-                         [
-                           Interface
-                             (Hashtbl.find schemaState.interfaces entry.id);
-                         ]
-                     | Some item ->
-                       Hashtbl.replace processedSchema.interfaceImplementedBy
-                         intfId
-                         (Interface
-                            (Hashtbl.find schemaState.interfaces entry.id)
-                         :: item))));
+                     registerInterfaceImplementedBy processedSchema intfId
+                       (Interface (Hashtbl.find schemaState.interfaces entry.id)))
+               ));
           lastEndlingLine := endingLineNum);
       close_in fileChannel);
+
+  schemaState.types |> hashtblToListAlphabetically
+  |> List.iter (fun (_id, (typ : gqlObjectType)) ->
+      typ.explicitInterfaces
+      |> List.iter (fun {interfaceName; loc; fileUri} ->
+          match findInterfaceByName schemaState interfaceName with
+          | None ->
+            schemaState
+            |> addDiagnostic
+                 ~diagnostic:
+                   {
+                     loc;
+                     fileUri;
+                     message =
+                       Printf.sprintf
+                         "`%s` declares @gql.implements(\"%s\"), but no \
+                          @gql.interface named `%s` exists."
+                         typ.displayName interfaceName interfaceName;
+                   }
+          | Some intf ->
+            let currentTyp = Hashtbl.find schemaState.types typ.id in
+            Hashtbl.replace schemaState.types typ.id
+              {
+                currentTyp with
+                interfaces = appendUniqueString currentTyp.interfaces intf.id;
+              };
+            registerInterfaceImplementedBy processedSchema intf.id
+              (ObjectType (Hashtbl.find schemaState.types typ.id))));
+
+  schemaState.interfaces |> hashtblToListAlphabetically
+  |> List.iter (fun (_id, (typ : gqlInterface)) ->
+      typ.explicitInterfaces
+      |> List.iter (fun {interfaceName; loc; fileUri} ->
+          match findInterfaceByName schemaState interfaceName with
+          | None ->
+            schemaState
+            |> addDiagnostic
+                 ~diagnostic:
+                   {
+                     loc;
+                     fileUri;
+                     message =
+                       Printf.sprintf
+                         "`%s` declares @gql.implements(\"%s\"), but no \
+                          @gql.interface named `%s` exists."
+                         typ.displayName interfaceName interfaceName;
+                   }
+          | Some intf ->
+            let currentTyp = Hashtbl.find schemaState.interfaces typ.id in
+            Hashtbl.replace schemaState.interfaces typ.id
+              {
+                currentTyp with
+                interfaces = appendUniqueString currentTyp.interfaces intf.id;
+              };
+            registerInterfaceImplementedBy processedSchema intf.id
+              (Interface (Hashtbl.find schemaState.interfaces typ.id))));
+
+  expandTransitiveInterfaceImplementations schemaState processedSchema;
+  inheritInterfaceResolverFields schemaState;
+  finalizeConcreteInterfaceImplementations processedSchema;
+
+  validateInterfaceImplementations schemaState;
 
   (* Remove any interface that isn't actually implemented by any type or
      interface. Otherwise the codegen we do for interfaces will error out on a

--- a/src/ml/GenerateSchemaValidation.ml
+++ b/src/ml/GenerateSchemaValidation.ml
@@ -70,6 +70,207 @@ let validateFields ~schemaState ~(parentTypeName : string)
              ~fileUri:f.fileUri)
         schemaState)
 
+let scalarToString (scalar : scalar) =
+  match scalar with
+  | Int -> "Int"
+  | Float -> "Float"
+  | String -> "String"
+  | Boolean -> "Boolean"
+  | ID -> "ID"
+
+let rec graphqlTypeToString ?(nullable = false) (typ : graphqlType) =
+  let nullableSuffix = if nullable then "" else "!" in
+  match typ with
+  | List inner ->
+    Printf.sprintf "[%s]%s" (graphqlTypeToString inner) nullableSuffix
+  | Nullable inner | RescriptNullable inner ->
+    graphqlTypeToString ~nullable:true inner
+  | Scalar scalar -> scalarToString scalar ^ nullableSuffix
+  | EmptyPayload -> graphqlTypeToString ~nullable:true (Scalar Boolean)
+  | InjectContext -> "<context>"
+  | InjectInfo -> "<info>"
+  | InjectInterfaceTypename intfId -> intfId ^ nullableSuffix
+  | GraphQLObjectType {displayName}
+  | GraphQLInputObject {displayName}
+  | GraphQLInputUnion {displayName}
+  | GraphQLEnum {displayName}
+  | GraphQLUnion {displayName}
+  | GraphQLInterface {displayName}
+  | GraphQLScalar {displayName} ->
+    displayName ^ nullableSuffix
+
+let nullableInner (typ : graphqlType) =
+  match typ with
+  | Nullable inner | RescriptNullable inner -> Some inner
+  | EmptyPayload -> Some (Scalar Boolean)
+  | _ -> None
+
+let rec sameGraphQLType left right =
+  match (nullableInner left, nullableInner right) with
+  | Some left, Some right -> sameGraphQLType left right
+  | Some _, None | None, Some _ -> false
+  | None, None -> (
+    match (left, right) with
+    | List left, List right -> sameGraphQLType left right
+    | Scalar left, Scalar right -> left = right
+    | InjectContext, InjectContext -> true
+    | InjectInfo, InjectInfo -> true
+    | InjectInterfaceTypename left, InjectInterfaceTypename right ->
+      left = right
+    | GraphQLObjectType left, GraphQLObjectType right -> left.id = right.id
+    | GraphQLInputObject left, GraphQLInputObject right -> left.id = right.id
+    | GraphQLEnum left, GraphQLEnum right -> left.id = right.id
+    | GraphQLUnion left, GraphQLUnion right -> left.id = right.id
+    | GraphQLInterface left, GraphQLInterface right -> left.id = right.id
+    | GraphQLScalar left, GraphQLScalar right -> left.id = right.id
+    | GraphQLInputUnion left, GraphQLInputUnion right ->
+      left.id = right.id
+      && left.inlineRecords = right.inlineRecords
+      && left.emptyPayloads = right.emptyPayloads
+    | EmptyPayload, EmptyPayload -> true
+    | _ -> false)
+
+let interfaceTransitivelyImplements schemaState interfaceId expectedId =
+  let rec loop ~visited interfaceId =
+    if List.mem interfaceId visited then false
+    else
+      interfaceId = expectedId
+      ||
+      match Hashtbl.find_opt schemaState.interfaces interfaceId with
+      | None -> false
+      | Some intf ->
+        intf.interfaces
+        |> List.exists (fun nextInterfaceId ->
+            loop ~visited:(interfaceId :: visited) nextInterfaceId)
+  in
+  loop ~visited:[] interfaceId
+
+let namedOutputSubtype schemaState ~actual ~expected =
+  sameGraphQLType actual expected
+  ||
+  match (actual, expected) with
+  | GraphQLObjectType actualObject, GraphQLInterface expectedInterface -> (
+    match Hashtbl.find_opt schemaState.types actualObject.id with
+    | None -> false
+    | Some typ ->
+      typ.interfaces
+      |> List.exists (fun intfId ->
+          interfaceTransitivelyImplements schemaState intfId
+            expectedInterface.id))
+  | GraphQLInterface actualInterface, GraphQLInterface expectedInterface ->
+    interfaceTransitivelyImplements schemaState actualInterface.id
+      expectedInterface.id
+  | GraphQLObjectType actualObject, GraphQLUnion expectedUnion -> (
+    match Hashtbl.find_opt schemaState.unions expectedUnion.id with
+    | None -> false
+    | Some union ->
+      union.types
+      |> List.exists (fun (member : gqlUnionMember) ->
+          member.objectTypeId = actualObject.id))
+  | _ -> false
+
+let rec isOutputSubtype schemaState ~actual ~expected =
+  match nullableInner expected with
+  | Some expectedInner -> (
+    match nullableInner actual with
+    | Some actualInner ->
+      isOutputSubtype schemaState ~actual:actualInner ~expected:expectedInner
+    | None -> isOutputSubtype schemaState ~actual ~expected:expectedInner)
+  | None -> (
+    match nullableInner actual with
+    | Some _ -> false
+    | None -> (
+      match (actual, expected) with
+      | List actual, List expected ->
+        isOutputSubtype schemaState ~actual ~expected
+      | _ -> namedOutputSubtype schemaState ~actual ~expected))
+
+let isRequiredInputType typ = nullableInner typ |> Option.is_none
+
+let findFieldByName fields name =
+  fields |> List.find_opt (fun (field : gqlField) -> field.name = name)
+
+let findArgByName args name =
+  args |> List.find_opt (fun (arg : gqlArg) -> arg.name = name)
+
+let isSchemaVisibleArg (arg : gqlArg) =
+  match arg.typ with
+  | InjectContext | InjectInfo | InjectInterfaceTypename _ -> false
+  | _ -> true
+
+let addInterfaceImplementationDiagnostic schemaState ~loc ~fileUri message =
+  schemaState |> addDiagnostic ~diagnostic:{loc; fileUri; message}
+
+let validateInterfaceFieldArguments ~schemaState ~loc ~fileUri
+    ~implementingTypeName ~interfaceName ~(implementationField : gqlField)
+    ~(interfaceField : gqlField) =
+  let interfaceArgs = interfaceField.args |> List.filter isSchemaVisibleArg in
+  let implementationArgs =
+    implementationField.args |> List.filter isSchemaVisibleArg
+  in
+  interfaceArgs
+  |> List.iter (fun (interfaceArg : gqlArg) ->
+      match findArgByName implementationArgs interfaceArg.name with
+      | None ->
+        addInterfaceImplementationDiagnostic schemaState ~loc ~fileUri
+          (Printf.sprintf
+             "`%s` cannot implement `%s`: field `%s` is missing argument `%s`."
+             implementingTypeName interfaceName interfaceField.name
+             interfaceArg.name)
+      | Some implementationArg ->
+        if sameGraphQLType implementationArg.typ interfaceArg.typ = false then
+          addInterfaceImplementationDiagnostic schemaState ~loc ~fileUri
+            (Printf.sprintf
+               "`%s` cannot implement `%s`: argument `%s` on field `%s` has \
+                type `%s` but the interface requires `%s`."
+               implementingTypeName interfaceName interfaceArg.name
+               interfaceField.name
+               (graphqlTypeToString implementationArg.typ)
+               (graphqlTypeToString interfaceArg.typ)));
+  implementationArgs
+  |> List.iter (fun (implementationArg : gqlArg) ->
+      match findArgByName interfaceArgs implementationArg.name with
+      | Some _ -> ()
+      | None ->
+        if isRequiredInputType implementationArg.typ then
+          addInterfaceImplementationDiagnostic schemaState ~loc ~fileUri
+            (Printf.sprintf
+               "`%s` cannot implement `%s`: field `%s` adds required argument \
+                `%s`, which is not allowed by GraphQL interface \
+                implementations."
+               implementingTypeName interfaceName interfaceField.name
+               implementationArg.name))
+
+let validateInterfaceImplementation ~schemaState ~loc ~fileUri
+    ~implementingTypeName ~(implementingFields : gqlField list)
+    ~(interface : gqlInterface) =
+  interface.fields
+  |> List.iter (fun (interfaceField : gqlField) ->
+      match findFieldByName implementingFields interfaceField.name with
+      | None ->
+        addInterfaceImplementationDiagnostic schemaState ~loc ~fileUri
+          (Printf.sprintf
+             "`%s` declares @gql.implements(\"%s\") but is missing field `%s: \
+              %s`."
+             implementingTypeName interface.displayName interfaceField.name
+             (graphqlTypeToString interfaceField.typ))
+      | Some implementationField ->
+        if
+          isOutputSubtype schemaState ~actual:implementationField.typ
+            ~expected:interfaceField.typ
+          = false
+        then
+          addInterfaceImplementationDiagnostic schemaState ~loc ~fileUri
+            (Printf.sprintf
+               "`%s` cannot implement `%s`: field `%s` has type `%s` but the \
+                interface requires `%s`."
+               implementingTypeName interface.displayName interfaceField.name
+               (graphqlTypeToString implementationField.typ)
+               (graphqlTypeToString interfaceField.typ));
+        validateInterfaceFieldArguments ~schemaState ~loc ~fileUri
+          ~implementingTypeName ~interfaceName:interface.displayName
+          ~implementationField ~interfaceField)
+
 let validateRootTypes (schemaState : schemaState) =
   match schemaState.query with
   | None ->
@@ -83,8 +284,38 @@ let validateRootTypes (schemaState : schemaState) =
            }
   | Some _ -> ()
 
+let validateInterfaceImplementationCycles (schemaState : schemaState) =
+  let rec hasCycle ~targetInterfaceId ~visited intfId =
+    if List.mem intfId visited then false
+    else
+      match Hashtbl.find_opt schemaState.interfaces intfId with
+      | None -> false
+      | Some intf ->
+        intf.interfaces
+        |> List.exists (fun parentInterfaceId ->
+            parentInterfaceId = targetInterfaceId
+            || hasCycle ~targetInterfaceId ~visited:(intfId :: visited)
+                 parentInterfaceId)
+  in
+  schemaState.interfaces
+  |> Hashtbl.iter (fun _name (typ : gqlInterface) ->
+      if hasCycle ~targetInterfaceId:typ.id ~visited:[] typ.id then
+        schemaState
+        |> addDiagnostic
+             ~diagnostic:
+               {
+                 loc = typ.typeLocation.loc;
+                 fileUri = typ.typeLocation.fileUri;
+                 message =
+                   Printf.sprintf
+                     "Interface `%s` cannot implement itself, directly or \
+                      through another interface."
+                     typ.displayName;
+               })
+
 let validateSchema (schemaState : schemaState) =
   validateRootTypes schemaState;
+  validateInterfaceImplementationCycles schemaState;
 
   schemaState.scalars
   |> Hashtbl.iter (fun _name (typ : gqlScalar) ->

--- a/tests/invalid-interface-implements.sh
+++ b/tests/invalid-interface-implements.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cleanup_all() {
+  rm -rf .tmp-*.??????
+}
+trap cleanup_all EXIT
+
+run_fixture() {
+  local name="$1"
+  local expected="$2"
+  local tmp_dir
+  tmp_dir="$(mktemp -d ".tmp-${name}.XXXXXX")"
+
+  cleanup() {
+    rm -rf "$tmp_dir"
+  }
+  trap cleanup RETURN
+
+  mkdir -p "$tmp_dir/src"
+
+  cat > "$tmp_dir/rescript.json" <<'JSON'
+{
+  "name": "resgraph-invalid-interface-implements-test",
+  "uncurried": true,
+  "package-specs": {
+    "in-source": true,
+    "module": "esmodule",
+    "suffix": ".mjs"
+  },
+  "sources": [
+    {
+      "dir": "../../src/res",
+      "subdirs": true
+    },
+    {
+      "dir": "src",
+      "subdirs": true
+    }
+  ],
+  "compiler-flags": ["-w -33-44"],
+  "dependencies": ["@glennsl/rescript-fetch", "rescript-nodejs"]
+}
+JSON
+
+  cat > "$tmp_dir/src/Query.res" <<'RES'
+@gql.type
+type query
+RES
+
+  cat > "$tmp_dir/src/ResGraphContext.res" <<'RES'
+type t = unit
+RES
+
+  cat > "$tmp_dir/src/App.res" <<'RES'
+@@warning("-32")
+
+RES
+  cat >> "$tmp_dir/src/App.res"
+
+  (
+    cd "$tmp_dir"
+    ../node_modules/.bin/rescript
+  )
+
+  local output
+  set +e
+  output="$(../bin/dev/resgraph.exe generate-schema "$tmp_dir/src" "$tmp_dir/src/__generated__" true)"
+  set -e
+
+  if ! printf "%s" "$output" | grep -q '"status": "Error"'; then
+    printf "Expected fixture %s to fail, but it succeeded.\n%s\n" "$name" "$output"
+    exit 1
+  fi
+
+  if ! printf "%s" "$output" | grep -q "$expected"; then
+    printf "Expected fixture %s to include diagnostic %s, got:\n%s\n" "$name" "$expected" "$output"
+    exit 1
+  fi
+}
+
+run_fixture "missing-interface" "no @gql.interface named" <<'RES'
+@gql.implements("Missing")
+@gql.type
+type broken = {
+  @gql.field name: string,
+}
+
+@gql.field
+let broken = (_: Query.query): broken => {name: "broken"}
+RES
+
+run_fixture "invalid-payload" '`@gql.implements` requires a string literal' <<'RES'
+@gql.implements(1)
+@gql.type
+type broken = {
+  @gql.field name: string,
+}
+
+@gql.field
+let broken = (_: Query.query): broken => {name: "broken"}
+RES
+
+run_fixture "unsupported-target" 'can only be used on @gql.type or @gql.interface records' <<'RES'
+@gql.interface
+type named = {
+  @gql.field name: string,
+}
+
+@gql.implements("Named")
+@gql.inputObject
+type brokenInput = {
+  name: string,
+}
+RES
+
+run_fixture "missing-field" 'missing field `name: String!`' <<'RES'
+@gql.interface
+type named = {
+  @gql.field name: string,
+}
+
+@gql.implements("Named")
+@gql.type
+type broken = {
+  @gql.field title: string,
+}
+
+@gql.field
+let broken = (_: Query.query): broken => {title: "broken"}
+RES
+
+run_fixture "field-type-mismatch" 'field `name` has type `Int!` but the interface requires `String!`' <<'RES'
+@gql.interface
+type named = {
+  @gql.field name: string,
+}
+
+@gql.implements("Named")
+@gql.type
+type broken = {
+  @gql.field name: int,
+}
+
+@gql.field
+let broken = (_: Query.query): broken => {name: 1}
+RES
+
+run_fixture "missing-argument" 'field `items` is missing argument `first`' <<'RES'
+@gql.interface
+type searchable = {
+  @gql.field id: string,
+}
+
+@gql.field
+let items = (_: searchable, ~first: int): string => Int.toString(first)
+
+@gql.implements("Searchable")
+@gql.type
+type broken = {
+  @gql.field id: string,
+}
+
+@gql.field
+let items = (_: broken): string => "broken"
+
+@gql.field
+let broken = (_: Query.query): broken => {id: "1"}
+RES
+
+run_fixture "argument-type-mismatch" 'argument `first` on field `items` has type `String!` but the interface requires `Int!`' <<'RES'
+@gql.interface
+type searchable = {
+  @gql.field id: string,
+}
+
+@gql.field
+let items = (_: searchable, ~first: int): string => Int.toString(first)
+
+@gql.implements("Searchable")
+@gql.type
+type broken = {
+  @gql.field id: string,
+}
+
+@gql.field
+let items = (_: broken, ~first: string): string => first
+
+@gql.field
+let broken = (_: Query.query): broken => {id: "1"}
+RES
+
+run_fixture "extra-required-argument" 'adds required argument `required`' <<'RES'
+@gql.interface
+type searchable = {
+  @gql.field id: string,
+}
+
+@gql.field
+let items = (_: searchable): string => "ok"
+
+@gql.implements("Searchable")
+@gql.type
+type broken = {
+  @gql.field id: string,
+}
+
+@gql.field
+let items = (_: broken, ~required: string): string => required
+
+@gql.field
+let broken = (_: Query.query): broken => {id: "1"}
+RES
+
+run_fixture "interface-to-interface-missing-field" 'missing field `name: String!`' <<'RES'
+@gql.interface
+type named = {
+  @gql.field name: string,
+}
+
+@gql.implements("Named")
+@gql.interface
+type brokenInterface = {
+  @gql.field id: string,
+}
+
+@gql.implements("BrokenInterface")
+@gql.type
+type broken = {
+  @gql.field id: string,
+}
+
+@gql.field
+let broken = (_: Query.query): broken => {id: "1"}
+RES
+
+run_fixture "interface-cycle" 'cannot implement itself' <<'RES'
+@gql.implements("B")
+@gql.interface
+type a = {
+  @gql.field id: string,
+}
+
+@gql.implements("A")
+@gql.interface
+type b = {
+  @gql.field id: string,
+}
+
+@gql.implements("A")
+@gql.type
+type broken = {
+  @gql.field id: string,
+}
+
+@gql.field
+let broken = (_: Query.query): broken => {id: "1"}
+RES

--- a/tests/runtime-interface-returns.mjs
+++ b/tests/runtime-interface-returns.mjs
@@ -152,4 +152,80 @@ assert.deepEqual(plain(reservedArgument.data), {
   reservedWordArgumentEcho: "arg constraint",
 });
 
+const explicitNamed = await run(`
+  query ExplicitNamed {
+    explicitNamed {
+      __typename
+      ... on ExplicitCompany {
+        name
+        entityKind
+      }
+    }
+  }
+`);
+
+assert.equal(explicitNamed.errors, undefined);
+assert.deepEqual(plain(explicitNamed.data), {
+  explicitNamed: {
+    __typename: "ExplicitCompany",
+    name: "Informind",
+    entityKind: "Company",
+  },
+});
+
+const explicitSearchable = await run(`
+  query ExplicitSearchable {
+    explicitSearchable {
+      __typename
+      ... on ExplicitSearchResult {
+        id
+        label(prefix: "result")
+      }
+    }
+  }
+`);
+
+assert.equal(explicitSearchable.errors, undefined);
+assert.deepEqual(plain(explicitSearchable.data), {
+  explicitSearchable: {
+    __typename: "ExplicitSearchResult",
+    id: "search-result",
+    label: "result:searchable",
+  },
+});
+
+const explicitContextResult = await run(`
+  query ExplicitContextResult {
+    explicitContextResult {
+      id
+      contextLabel
+    }
+  }
+`);
+
+assert.equal(explicitContextResult.errors, undefined);
+assert.deepEqual(plain(explicitContextResult.data), {
+  explicitContextResult: {
+    id: "ctx-result",
+    contextLabel: "override-no-ctx",
+  },
+});
+
+const explicitContextOverrideResult = await run(`
+  query ExplicitContextOverrideResult {
+    explicitContextOverrideResult {
+      id
+      contextOverrideLabel
+    }
+  }
+`);
+
+assert.equal(explicitContextOverrideResult.errors, undefined);
+assert.deepEqual(plain(explicitContextOverrideResult.data), {
+  explicitContextOverrideResult: {
+    id: "ctx-override-result",
+    contextOverrideLabel: "override:123",
+  },
+});
+
 console.log("runtime regressions passed");

--- a/tests/src/AppExplicitInterfaceImplements.res
+++ b/tests/src/AppExplicitInterfaceImplements.res
@@ -1,0 +1,136 @@
+@@warning("-32")
+
+@gql.interface
+type named = {
+  @gql.field name: string,
+}
+
+@gql.interface
+type ranked = {
+  @gql.field rank: int,
+}
+
+@gql.interface
+type nullableNamed = {
+  @gql.field nullableName: option<string>,
+}
+
+@gql.implements("Named")
+@gql.interface
+type namedEntity = {
+  @gql.field name: string,
+  @gql.field entityKind: string,
+}
+
+@gql.interface
+type companyHolder = {
+  @gql.field company: namedEntity,
+}
+
+@gql.interface
+type searchable = {
+  @gql.field id: string,
+}
+
+@gql.field
+let label = (_: searchable, ~prefix: option<string>=?): string =>
+  switch prefix {
+  | Some(prefix) => prefix ++ ":searchable"
+  | None => "searchable"
+  }
+
+@gql.interface
+type contextual = {
+  @gql.field id: string,
+}
+
+@gql.field
+let contextLabel = (_: contextual, ~ctx: ResGraphContext.context): string =>
+  switch ctx.currentUserId {
+  | Some(id) => "ctx:" ++ id
+  | None => "ctx:none"
+  }
+
+@gql.interface
+type contextOverride = {
+  @gql.field id: string,
+}
+
+@gql.field
+let contextOverrideLabel = (_: contextOverride): string => "base"
+
+@gql.implements("NamedEntity")
+@gql.implements("NullableNamed")
+@gql.implements("Ranked")
+@gql.type
+type explicitCompany = {
+  @gql.field name: string,
+  @gql.field entityKind: string,
+  @gql.field nullableName: string,
+  @gql.field rank: int,
+  @gql.field headquarters: option<string>,
+}
+
+@gql.implements("CompanyHolder")
+@gql.type
+type explicitCompanyHolder = {
+  @gql.field company: explicitCompany,
+}
+
+@gql.implements("Searchable")
+@gql.type
+type explicitSearchResult = {
+  @gql.field id: string,
+}
+
+@gql.implements("Contextual")
+@gql.type
+type explicitContextResult = {
+  @gql.field id: string,
+}
+
+@gql.field
+let contextLabel = (_: explicitContextResult): string => "override-no-ctx"
+
+@gql.implements("ContextOverride")
+@gql.type
+type explicitContextOverrideResult = {
+  @gql.field id: string,
+}
+
+@gql.field
+let contextOverrideLabel = (
+  _: explicitContextOverrideResult,
+  ~ctx: ResGraphContext.context,
+): string =>
+  switch ctx.currentUserId {
+  | Some(id) => "override:" ++ id
+  | None => "override:none"
+  }
+
+let makeExplicitCompany = (): explicitCompany => {
+  name: "Informind",
+  entityKind: "Company",
+  nullableName: "Informind",
+  rank: 1,
+  headquarters: Some("Stockholm"),
+}
+
+@gql.field
+let explicitCompany = (_: Query.query): explicitCompany => makeExplicitCompany()
+
+@gql.field
+let explicitCompanyHolder = (_: Query.query): explicitCompanyHolder => {
+  company: makeExplicitCompany(),
+}
+
+@gql.field
+let explicitSearchResult = (_: Query.query): explicitSearchResult => {id: "search-result"}
+
+@gql.field
+let explicitContextResult = (_: Query.query): explicitContextResult => {id: "ctx-result"}
+
+@gql.field
+let explicitContextOverrideResult = (_: Query.query): explicitContextOverrideResult => {
+  id: "ctx-override-result",
+}

--- a/tests/src/AppExplicitInterfaceReturns.res
+++ b/tests/src/AppExplicitInterfaceReturns.res
@@ -1,0 +1,7 @@
+@gql.field
+let explicitNamed = (_: Query.query): Interface_named.Resolver.t =>
+  ExplicitCompany(AppExplicitInterfaceImplements.makeExplicitCompany())
+
+@gql.field
+let explicitSearchable = (_: Query.query): Interface_searchable.Resolver.t =>
+  ExplicitSearchResult({id: "search-result"})

--- a/tests/src/__generated__/ResGraphSchema.res
+++ b/tests/src/__generated__/ResGraphSchema.res
@@ -101,10 +101,36 @@ let scalar_Uuid = GraphQLScalar.make({
   name: "Uuid",
   description: "Custom scalar with specifiedByUrl coverage.",
 })
+let i_CompanyHolder: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
+let get_CompanyHolder = () => i_CompanyHolder.contents
+let i_ContextOverride: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
+let get_ContextOverride = () => i_ContextOverride.contents
+let i_Contextual: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
+let get_Contextual = () => i_Contextual.contents
 let i_Labelled: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
 let get_Labelled = () => i_Labelled.contents
+let i_Named: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
+let get_Named = () => i_Named.contents
+let i_NamedEntity: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
+let get_NamedEntity = () => i_NamedEntity.contents
 let i_Node: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
 let get_Node = () => i_Node.contents
+let i_NullableNamed: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
+let get_NullableNamed = () => i_NullableNamed.contents
+let i_Ranked: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
+let get_Ranked = () => i_Ranked.contents
+let i_Searchable: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
+let get_Searchable = () => i_Searchable.contents
+let t_ExplicitCompany: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
+let get_ExplicitCompany = () => t_ExplicitCompany.contents
+let t_ExplicitCompanyHolder: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
+let get_ExplicitCompanyHolder = () => t_ExplicitCompanyHolder.contents
+let t_ExplicitContextOverrideResult: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
+let get_ExplicitContextOverrideResult = () => t_ExplicitContextOverrideResult.contents
+let t_ExplicitContextResult: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
+let get_ExplicitContextResult = () => t_ExplicitContextResult.contents
+let t_ExplicitSearchResult: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
+let get_ExplicitSearchResult = () => t_ExplicitSearchResult.contents
 let t_FunctionFieldRegression: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
 let get_FunctionFieldRegression = () => t_FunctionFieldRegression.contents
 let t_LabelledAlpha: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
@@ -275,6 +301,30 @@ inputUnion_UpdatableString_conversionInstructions->Array.pushMany([
   ("leaveUnchanged", makeInputObjectFieldConverterFn(v => v->Nullable.toOption)),
 ])
 
+let interface_CompanyHolder_resolveType = (v: Interface_companyHolder.Resolver.t) =>
+  resolveInterfaceTypename(
+    v,
+    ["ExplicitCompanyHolder"],
+    "CompanyHolder",
+    "Interface_companyHolder.Resolver.t",
+  )
+
+let interface_ContextOverride_resolveType = (v: Interface_contextOverride.Resolver.t) =>
+  resolveInterfaceTypename(
+    v,
+    ["ExplicitContextOverrideResult"],
+    "ContextOverride",
+    "Interface_contextOverride.Resolver.t",
+  )
+
+let interface_Contextual_resolveType = (v: Interface_contextual.Resolver.t) =>
+  resolveInterfaceTypename(
+    v,
+    ["ExplicitContextResult"],
+    "Contextual",
+    "Interface_contextual.Resolver.t",
+  )
+
 let interface_Labelled_resolveType = (v: Interface_labelled.Resolver.t) =>
   resolveInterfaceTypename(
     v,
@@ -283,9 +333,93 @@ let interface_Labelled_resolveType = (v: Interface_labelled.Resolver.t) =>
     "Interface_labelled.Resolver.t",
   )
 
+let interface_Named_resolveType = (v: Interface_named.Resolver.t) =>
+  resolveInterfaceTypename(v, ["ExplicitCompany"], "Named", "Interface_named.Resolver.t")
+
+let interface_NamedEntity_resolveType = (v: Interface_namedEntity.Resolver.t) =>
+  resolveInterfaceTypename(
+    v,
+    ["ExplicitCompany"],
+    "NamedEntity",
+    "Interface_namedEntity.Resolver.t",
+  )
+
 let interface_Node_resolveType = (v: Interface_node.Resolver.t) =>
   resolveInterfaceTypename(v, ["Thing"], "Node", "Interface_node.Resolver.t")
 
+let interface_NullableNamed_resolveType = (v: Interface_nullableNamed.Resolver.t) =>
+  resolveInterfaceTypename(
+    v,
+    ["ExplicitCompany"],
+    "NullableNamed",
+    "Interface_nullableNamed.Resolver.t",
+  )
+
+let interface_Ranked_resolveType = (v: Interface_ranked.Resolver.t) =>
+  resolveInterfaceTypename(v, ["ExplicitCompany"], "Ranked", "Interface_ranked.Resolver.t")
+
+let interface_Searchable_resolveType = (v: Interface_searchable.Resolver.t) =>
+  resolveInterfaceTypename(
+    v,
+    ["ExplicitSearchResult"],
+    "Searchable",
+    "Interface_searchable.Resolver.t",
+  )
+
+i_CompanyHolder.contents = GraphQLInterfaceType.make({
+  name: "CompanyHolder",
+  description: ?None,
+  interfaces: [],
+  fields: () =>
+    {
+      "company": {
+        typ: get_NamedEntity()->GraphQLInterfaceType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+    }->makeFields,
+  resolveType: GraphQLInterfaceType.makeResolveInterfaceTypeFn(interface_CompanyHolder_resolveType),
+})
+i_ContextOverride.contents = GraphQLInterfaceType.make({
+  name: "ContextOverride",
+  description: ?None,
+  interfaces: [],
+  fields: () =>
+    {
+      "contextOverrideLabel": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+      "id": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+    }->makeFields,
+  resolveType: GraphQLInterfaceType.makeResolveInterfaceTypeFn(
+    interface_ContextOverride_resolveType,
+  ),
+})
+i_Contextual.contents = GraphQLInterfaceType.make({
+  name: "Contextual",
+  description: ?None,
+  interfaces: [],
+  fields: () =>
+    {
+      "contextLabel": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+      "id": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+    }->makeFields,
+  resolveType: GraphQLInterfaceType.makeResolveInterfaceTypeFn(interface_Contextual_resolveType),
+})
 i_Labelled.contents = GraphQLInterfaceType.make({
   name: "Labelled",
   description: ?None,
@@ -300,6 +434,39 @@ i_Labelled.contents = GraphQLInterfaceType.make({
     }->makeFields,
   resolveType: GraphQLInterfaceType.makeResolveInterfaceTypeFn(interface_Labelled_resolveType),
 })
+i_Named.contents = GraphQLInterfaceType.make({
+  name: "Named",
+  description: ?None,
+  interfaces: [],
+  fields: () =>
+    {
+      "name": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+    }->makeFields,
+  resolveType: GraphQLInterfaceType.makeResolveInterfaceTypeFn(interface_Named_resolveType),
+})
+i_NamedEntity.contents = GraphQLInterfaceType.make({
+  name: "NamedEntity",
+  description: ?None,
+  interfaces: [get_Named()],
+  fields: () =>
+    {
+      "entityKind": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+      "name": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+    }->makeFields,
+  resolveType: GraphQLInterfaceType.makeResolveInterfaceTypeFn(interface_NamedEntity_resolveType),
+})
 i_Node.contents = GraphQLInterfaceType.make({
   name: "Node",
   description: "An object with an ID",
@@ -313,6 +480,203 @@ i_Node.contents = GraphQLInterfaceType.make({
       },
     }->makeFields,
   resolveType: GraphQLInterfaceType.makeResolveInterfaceTypeFn(interface_Node_resolveType),
+})
+i_NullableNamed.contents = GraphQLInterfaceType.make({
+  name: "NullableNamed",
+  description: ?None,
+  interfaces: [],
+  fields: () =>
+    {
+      "nullableName": {
+        typ: Scalars.string->Scalars.toGraphQLType,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+    }->makeFields,
+  resolveType: GraphQLInterfaceType.makeResolveInterfaceTypeFn(interface_NullableNamed_resolveType),
+})
+i_Ranked.contents = GraphQLInterfaceType.make({
+  name: "Ranked",
+  description: ?None,
+  interfaces: [],
+  fields: () =>
+    {
+      "rank": {
+        typ: Scalars.int->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+    }->makeFields,
+  resolveType: GraphQLInterfaceType.makeResolveInterfaceTypeFn(interface_Ranked_resolveType),
+})
+i_Searchable.contents = GraphQLInterfaceType.make({
+  name: "Searchable",
+  description: ?None,
+  interfaces: [],
+  fields: () =>
+    {
+      "id": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+      },
+      "label": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        args: {"prefix": {typ: Scalars.string->Scalars.toGraphQLType}}->makeArgs,
+      },
+    }->makeFields,
+  resolveType: GraphQLInterfaceType.makeResolveInterfaceTypeFn(interface_Searchable_resolveType),
+})
+t_ExplicitCompany.contents = GraphQLObjectType.make({
+  name: "ExplicitCompany",
+  description: ?None,
+  interfaces: [get_Named(), get_NamedEntity(), get_NullableNamed(), get_Ranked()],
+  fields: () =>
+    {
+      "entityKind": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["entityKind"]
+        }),
+      },
+      "headquarters": {
+        typ: Scalars.string->Scalars.toGraphQLType,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["headquarters"]
+        }),
+      },
+      "name": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["name"]
+        }),
+      },
+      "nullableName": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["nullableName"]
+        }),
+      },
+      "rank": {
+        typ: Scalars.int->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["rank"]
+        }),
+      },
+    }->makeFields,
+})
+t_ExplicitCompanyHolder.contents = GraphQLObjectType.make({
+  name: "ExplicitCompanyHolder",
+  description: ?None,
+  interfaces: [get_CompanyHolder()],
+  fields: () =>
+    {
+      "company": {
+        typ: get_ExplicitCompany()->GraphQLObjectType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["company"]
+        }),
+      },
+    }->makeFields,
+})
+t_ExplicitContextOverrideResult.contents = GraphQLObjectType.make({
+  name: "ExplicitContextOverrideResult",
+  description: ?None,
+  interfaces: [get_ContextOverride()],
+  fields: () =>
+    {
+      "contextOverrideLabel": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppExplicitInterfaceImplements.contextOverrideLabel(src, ~ctx)
+        }),
+      },
+      "id": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["id"]
+        }),
+      },
+    }->makeFields,
+})
+t_ExplicitContextResult.contents = GraphQLObjectType.make({
+  name: "ExplicitContextResult",
+  description: ?None,
+  interfaces: [get_Contextual()],
+  fields: () =>
+    {
+      "contextLabel": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppExplicitInterfaceImplements.contextLabel(src)
+        }),
+      },
+      "id": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["id"]
+        }),
+      },
+    }->makeFields,
+})
+t_ExplicitSearchResult.contents = GraphQLObjectType.make({
+  name: "ExplicitSearchResult",
+  description: ?None,
+  interfaces: [get_Searchable()],
+  fields: () =>
+    {
+      "id": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, _args, _ctx, _info) => {
+          let src = typeUnwrapper(src)
+          src["id"]
+        }),
+      },
+      "label": {
+        typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        args: {"prefix": {typ: Scalars.string->Scalars.toGraphQLType}}->makeArgs,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppExplicitInterfaceImplements.label(src, ~prefix=?args["prefix"]->Nullable.toOption)
+        }),
+      },
+    }->makeFields,
 })
 t_FunctionFieldRegression.contents = GraphQLObjectType.make({
   name: "FunctionFieldRegression",
@@ -528,6 +892,69 @@ t_Query.contents = GraphQLObjectType.make({
         resolve: makeResolveFn((src, args, ctx, info) => {
           let src = typeUnwrapper(src)
           AppInterfaceReturnRegression.brokenLabelledWrapper(src)
+        }),
+      },
+      "explicitCompany": {
+        typ: get_ExplicitCompany()->GraphQLObjectType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppExplicitInterfaceImplements.explicitCompany(src)
+        }),
+      },
+      "explicitCompanyHolder": {
+        typ: get_ExplicitCompanyHolder()->GraphQLObjectType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppExplicitInterfaceImplements.explicitCompanyHolder(src)
+        }),
+      },
+      "explicitContextOverrideResult": {
+        typ: get_ExplicitContextOverrideResult()->GraphQLObjectType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppExplicitInterfaceImplements.explicitContextOverrideResult(src)
+        }),
+      },
+      "explicitContextResult": {
+        typ: get_ExplicitContextResult()->GraphQLObjectType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppExplicitInterfaceImplements.explicitContextResult(src)
+        }),
+      },
+      "explicitNamed": {
+        typ: get_Named()->GraphQLInterfaceType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppExplicitInterfaceReturns.explicitNamed(src)
+        }),
+      },
+      "explicitSearchResult": {
+        typ: get_ExplicitSearchResult()->GraphQLObjectType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppExplicitInterfaceImplements.explicitSearchResult(src)
+        }),
+      },
+      "explicitSearchable": {
+        typ: get_Searchable()->GraphQLInterfaceType.toGraphQLType->nonNull,
+        description: ?None,
+        deprecationReason: ?None,
+        resolve: makeResolveFn((src, args, ctx, info) => {
+          let src = typeUnwrapper(src)
+          AppExplicitInterfaceReturns.explicitSearchable(src)
         }),
       },
       "functionFieldRegression": {
@@ -1324,6 +1751,11 @@ let schema = GraphQLSchemaType.make({
   "mutation": get_Mutation(),
   "subscription": get_Subscription(),
   "types": [
+    get_ExplicitCompany()->GraphQLObjectType.toGraphQLType,
+    get_ExplicitCompanyHolder()->GraphQLObjectType.toGraphQLType,
+    get_ExplicitContextOverrideResult()->GraphQLObjectType.toGraphQLType,
+    get_ExplicitContextResult()->GraphQLObjectType.toGraphQLType,
+    get_ExplicitSearchResult()->GraphQLObjectType.toGraphQLType,
     get_FunctionFieldRegression()->GraphQLObjectType.toGraphQLType,
     get_LabelledAlpha()->GraphQLObjectType.toGraphQLType,
     get_LabelledBeta()->GraphQLObjectType.toGraphQLType,
@@ -1343,8 +1775,16 @@ let schema = GraphQLSchemaType.make({
     get_User()->GraphQLObjectType.toGraphQLType,
     get_UserConnection()->GraphQLObjectType.toGraphQLType,
     get_UserEdge()->GraphQLObjectType.toGraphQLType,
+    get_CompanyHolder()->GraphQLInterfaceType.toGraphQLType,
+    get_ContextOverride()->GraphQLInterfaceType.toGraphQLType,
+    get_Contextual()->GraphQLInterfaceType.toGraphQLType,
     get_Labelled()->GraphQLInterfaceType.toGraphQLType,
+    get_Named()->GraphQLInterfaceType.toGraphQLType,
+    get_NamedEntity()->GraphQLInterfaceType.toGraphQLType,
     get_Node()->GraphQLInterfaceType.toGraphQLType,
+    get_NullableNamed()->GraphQLInterfaceType.toGraphQLType,
+    get_Ranked()->GraphQLInterfaceType.toGraphQLType,
+    get_Searchable()->GraphQLInterfaceType.toGraphQLType,
     get_Res12Input()->GraphQLInputObjectType.toGraphQLType,
     get_UpdatableBool()->GraphQLInputObjectType.toGraphQLType,
     get_UpdatableFloat()->GraphQLInputObjectType.toGraphQLType,

--- a/tests/src/__generated__/interface_companyHolder.res
+++ b/tests/src/__generated__/interface_companyHolder.res
@@ -1,0 +1,20 @@
+/* @generated */
+
+@@warning("-27-34-37")
+
+module Resolver = {
+  @gql.interfaceResolver("companyHolder")
+  type t = ExplicitCompanyHolder(AppExplicitInterfaceImplements.explicitCompanyHolder)
+}
+
+module ImplementedBy = {
+  type t = ExplicitCompanyHolder
+
+  let decode = (str: string) =>
+    switch str {
+    | "ExplicitCompanyHolder" => Some(ExplicitCompanyHolder)
+    | _ => None
+    }
+
+  external toString: t => string = "%identity"
+}

--- a/tests/src/__generated__/interface_contextOverride.res
+++ b/tests/src/__generated__/interface_contextOverride.res
@@ -1,0 +1,21 @@
+/* @generated */
+
+@@warning("-27-34-37")
+
+module Resolver = {
+  @gql.interfaceResolver("contextOverride")
+  type t =
+    ExplicitContextOverrideResult(AppExplicitInterfaceImplements.explicitContextOverrideResult)
+}
+
+module ImplementedBy = {
+  type t = ExplicitContextOverrideResult
+
+  let decode = (str: string) =>
+    switch str {
+    | "ExplicitContextOverrideResult" => Some(ExplicitContextOverrideResult)
+    | _ => None
+    }
+
+  external toString: t => string = "%identity"
+}

--- a/tests/src/__generated__/interface_contextual.res
+++ b/tests/src/__generated__/interface_contextual.res
@@ -1,0 +1,20 @@
+/* @generated */
+
+@@warning("-27-34-37")
+
+module Resolver = {
+  @gql.interfaceResolver("contextual")
+  type t = ExplicitContextResult(AppExplicitInterfaceImplements.explicitContextResult)
+}
+
+module ImplementedBy = {
+  type t = ExplicitContextResult
+
+  let decode = (str: string) =>
+    switch str {
+    | "ExplicitContextResult" => Some(ExplicitContextResult)
+    | _ => None
+    }
+
+  external toString: t => string = "%identity"
+}

--- a/tests/src/__generated__/interface_named.res
+++ b/tests/src/__generated__/interface_named.res
@@ -1,0 +1,20 @@
+/* @generated */
+
+@@warning("-27-34-37")
+
+module Resolver = {
+  @gql.interfaceResolver("named")
+  type t = ExplicitCompany(AppExplicitInterfaceImplements.explicitCompany)
+}
+
+module ImplementedBy = {
+  type t = ExplicitCompany
+
+  let decode = (str: string) =>
+    switch str {
+    | "ExplicitCompany" => Some(ExplicitCompany)
+    | _ => None
+    }
+
+  external toString: t => string = "%identity"
+}

--- a/tests/src/__generated__/interface_namedEntity.res
+++ b/tests/src/__generated__/interface_namedEntity.res
@@ -1,0 +1,20 @@
+/* @generated */
+
+@@warning("-27-34-37")
+
+module Resolver = {
+  @gql.interfaceResolver("namedEntity")
+  type t = ExplicitCompany(AppExplicitInterfaceImplements.explicitCompany)
+}
+
+module ImplementedBy = {
+  type t = ExplicitCompany
+
+  let decode = (str: string) =>
+    switch str {
+    | "ExplicitCompany" => Some(ExplicitCompany)
+    | _ => None
+    }
+
+  external toString: t => string = "%identity"
+}

--- a/tests/src/__generated__/interface_nullableNamed.res
+++ b/tests/src/__generated__/interface_nullableNamed.res
@@ -1,0 +1,20 @@
+/* @generated */
+
+@@warning("-27-34-37")
+
+module Resolver = {
+  @gql.interfaceResolver("nullableNamed")
+  type t = ExplicitCompany(AppExplicitInterfaceImplements.explicitCompany)
+}
+
+module ImplementedBy = {
+  type t = ExplicitCompany
+
+  let decode = (str: string) =>
+    switch str {
+    | "ExplicitCompany" => Some(ExplicitCompany)
+    | _ => None
+    }
+
+  external toString: t => string = "%identity"
+}

--- a/tests/src/__generated__/interface_ranked.res
+++ b/tests/src/__generated__/interface_ranked.res
@@ -1,0 +1,20 @@
+/* @generated */
+
+@@warning("-27-34-37")
+
+module Resolver = {
+  @gql.interfaceResolver("ranked")
+  type t = ExplicitCompany(AppExplicitInterfaceImplements.explicitCompany)
+}
+
+module ImplementedBy = {
+  type t = ExplicitCompany
+
+  let decode = (str: string) =>
+    switch str {
+    | "ExplicitCompany" => Some(ExplicitCompany)
+    | _ => None
+    }
+
+  external toString: t => string = "%identity"
+}

--- a/tests/src/__generated__/interface_searchable.res
+++ b/tests/src/__generated__/interface_searchable.res
@@ -1,0 +1,20 @@
+/* @generated */
+
+@@warning("-27-34-37")
+
+module Resolver = {
+  @gql.interfaceResolver("searchable")
+  type t = ExplicitSearchResult(AppExplicitInterfaceImplements.explicitSearchResult)
+}
+
+module ImplementedBy = {
+  type t = ExplicitSearchResult
+
+  let decode = (str: string) =>
+    switch str {
+    | "ExplicitSearchResult" => Some(ExplicitSearchResult)
+    | _ => None
+    }
+
+  external toString: t => string = "%identity"
+}

--- a/tests/src/__generated__/schema.graphql
+++ b/tests/src/__generated__/schema.graphql
@@ -72,8 +72,31 @@ input UpdatableString @oneOf {
   leaveUnchanged: Boolean
 }
 
+interface CompanyHolder {
+  company: NamedEntity!
+}
+
+interface ContextOverride {
+  contextOverrideLabel: String!
+  id: String!
+}
+
+interface Contextual {
+  contextLabel: String!
+  id: String!
+}
+
 interface Labelled {
   typenameEcho: String!
+}
+
+interface Named {
+  name: String!
+}
+
+interface NamedEntity implements Named {
+  name: String!
+  entityKind: String!
 }
 
 
@@ -82,6 +105,46 @@ interface Node {
 
   """The id of the object."""
   id: ID!
+}
+
+interface NullableNamed {
+  nullableName: String
+}
+
+interface Ranked {
+  rank: Int!
+}
+
+interface Searchable {
+  label(prefix: String): String!
+  id: String!
+}
+
+type ExplicitCompany implements NamedEntity & Named & NullableNamed & Ranked {
+  name: String!
+  entityKind: String!
+  nullableName: String!
+  rank: Int!
+  headquarters: String
+}
+
+type ExplicitCompanyHolder implements CompanyHolder {
+  company: ExplicitCompany!
+}
+
+type ExplicitContextOverrideResult implements ContextOverride {
+  contextOverrideLabel: String!
+  id: String!
+}
+
+type ExplicitContextResult implements Contextual {
+  contextLabel: String!
+  id: String!
+}
+
+type ExplicitSearchResult implements Searchable {
+  id: String!
+  label(prefix: String): String!
 }
 
 type FunctionFieldRegression {
@@ -147,6 +210,13 @@ type Query {
   labelledWrapper: LabelledWrapper!
   badLabelled: Labelled!
   goodLabelled: Labelled!
+  explicitSearchable: Searchable!
+  explicitNamed: Named!
+  explicitContextOverrideResult: ExplicitContextOverrideResult!
+  explicitContextResult: ExplicitContextResult!
+  explicitSearchResult: ExplicitSearchResult!
+  explicitCompanyHolder: ExplicitCompanyHolder!
+  explicitCompany: ExplicitCompany!
   getScalarHolder: ScalarHolder!
   nestedConnection: StringConnection!
   userConnection(first: Int, after: String): UserConnection!

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -12,3 +12,4 @@ else
 fi
 
 node ./runtime-interface-returns.mjs
+./invalid-interface-implements.sh


### PR DESCRIPTION
## Summary

Adds repeatable `@gql.implements("InterfaceName")` for object types and interfaces, while preserving the existing record-spread interface mechanism.

The new explicit path records implementation declarations separately from spreads, attaches them during schema processing without copying interface fields into the ReScript record, expands transitive parent interfaces required by GraphQL.js, and validates implementation parity before generated schema code is emitted.

README and interface docs now cover the explicit API alongside the existing spread style.

## Validation covered

- Missing implemented interface
- Invalid `@gql.implements` payload
- Unsupported `@gql.implements` target rejection
- Missing interface field
- Field output type mismatch
- GraphQL output subtype compatibility for nullable/non-null fields
- GraphQL output subtype compatibility for object-to-interface fields
- Transitive interface parent expansion for GraphQL.js schema validity
- Concrete-only interface resolver assets for interface-to-interface implementations
- Runtime explicit interface return resolution
- Runtime explicit interface field execution with extra nullable args
- Missing field argument
- Field argument type mismatch
- Extra required field argument rejection
- Extra nullable field argument acceptance
- Interface implementing another interface
- Interface implementation cycle rejection
- Existing spread-based implementations still generate

## Checks

- `make format`
- `make test`
- `make -C tests test`