### PR TITLE
Prepare 1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## Unreleased
 
-- Add opt-in required authorization coverage with typed `.authorize` policies, explicit `.public` dispositions, resolver outcomes, mutation prechecks, interface policy inheritance, custom forbidden handlers, and deterministic audit manifests.
-- Add named multi-schema configuration with explicit source membership, separate generated modules, contexts, authorization settings, state and caches, targeted build/watch and tooling selection, LSP routing, and safe stale-artifact cleanup while preserving the original single-schema configuration.
-
 ## 1.3.0
 
+- Add opt-in required authorization coverage with typed `.authorize` policies, explicit `.public` dispositions, resolver outcomes, mutation prechecks, interface policy inheritance, custom forbidden handlers, and deterministic audit manifests.
+- Add named multi-schema configuration with explicit source membership, separate generated modules, contexts, authorization settings, state and caches, targeted build/watch and tooling selection, LSP routing, and safe stale-artifact cleanup while preserving the original single-schema configuration.
 - Speed up schema generation by emitting formatted ReScript and SDL directly through linear, buffer-backed writers instead of reparsing and pretty-printing generated code.
 - Add a conservative persistent incremental cache that safely skips unchanged schema generation across separate ResGraph invocations.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resgraph",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resgraph",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "@glennsl/rescript-fetch": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resgraph",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Build GraphQL servers in ReScript.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump the npm package and lockfile metadata to 1.3.0
- fold authorization and multi-schema changes into the existing 1.3.0 changelog section
- keep an empty Unreleased section for subsequent work

## Validation

- `npm ci`
- `npm run build`
- `npm pack --dry-run --json` (verified package id `resgraph@1.3.0`)

After this merges and main CI is green, tag the merge commit as `v1.3.0`; the tag-triggered CI workflow will publish to npm with the `latest` dist-tag.