### PR TITLE
Add clean custom directive support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 tests/lib
 tests/**/*.mjs
 !tests/runtime-interface-returns.mjs
+!tests/runtime-directives.mjs
 tests/node_modules
 tests/.bsb.lock
 _build

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ ResGraph lets you build _implementation first_ GraphQL servers, where your types
 - [x] Unions
 - [x] Custom scalars (including custom serializers/parsers)
 - [x] [Required authorization coverage](https://zth.github.io/resgraph/docs/authorization)
-- [ ] Directives
+- [x] [Custom directives](https://zth.github.io/resgraph/docs/directives)
 - [x] Relay helpers (coming very soon)
 
 ## Development notes

--- a/docs/docs/directives.md
+++ b/docs/docs/directives.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 13
+---
+
+# Directives
+
+ResGraph supports custom directive definitions and type-system directive
+applications. Directives are schema metadata: declaring one does not wrap a
+resolver or give it runtime behavior automatically.
+
+## Define a directive
+
+Use a record when the directive has arguments. Record fields become directive
+arguments and use the normal ResGraph input-type mapping.
+
+```rescript
+/** Caching metadata consumed by an explicit schema transform. */
+@gql.directive({
+  locations: ["OBJECT", "FIELD_DEFINITION"],
+  repeatable: false,
+})
+type cacheControl = {
+  /** Maximum cache lifetime in seconds. */
+  @gql.default(60)
+  maxAge: int,
+  scope: option<string>,
+  @deprecated("Use scope instead.")
+  legacyScope: option<string>,
+}
+```
+
+This emits:
+
+```graphql
+"""Caching metadata consumed by an explicit schema transform."""
+directive @cacheControl(
+  """Maximum cache lifetime in seconds."""
+  maxAge: Int! = 60
+  scope: String
+  legacyScope: String @deprecated(reason: "Use scope instead.")
+) on OBJECT | FIELD_DEFINITION
+```
+
+Use an abstract type for a directive without arguments:
+
+```rescript
+@gql.directive({locations: ["FIELD_DEFINITION"]})
+type authenticated
+```
+
+`locations` accepts the standard GraphQL directive-location names. Definitions
+may include executable-document locations even though ResGraph only applies
+directives while building a schema. `repeatable` defaults to `false`.
+
+## Apply a directive
+
+Apply a directive with `@gql.annotate`. The `args` field is optional for a
+directive without arguments.
+
+```rescript
+@gql.annotate({name: "cacheControl", args: {maxAge: 30}})
+@gql.type
+type product = {
+  @gql.annotate({
+    name: "cacheControl",
+    args: {maxAge: 10, scope: "private"},
+  })
+  @gql.field
+  name: string,
+}
+```
+
+Arguments must be GraphQL constant values: null, booleans, integers, floats,
+strings or enum values, arrays, records, and nested combinations. ResGraph
+checks directive names, locations, repeatability, required and unknown
+arguments, and value coercion while generating the schema.
+
+Applications are currently supported on scalars, objects, interfaces, unions,
+enums, enum values, input objects, input fields, and output fields. Schema-level
+applications and resolver-argument applications are planned follow-ups.
+
+## Repeatable directives and order
+
+Repeat the attribute for a repeatable directive. ResGraph preserves exact
+source order in generated SDL and in
+`extensions.resgraph.appliedDirectives`.
+
+```rescript
+@gql.annotate({name: "tag", args: {name: "internal"}})
+@gql.annotate({name: "tag", args: {name: "beta"}})
+@gql.type
+type account = {
+  @gql.field id: ResGraph.id,
+}
+```
+
+For ecosystem interoperability, generated types also expose the conventional
+`extensions.directives` map consumed by GraphQL Tools' `getDirective` and
+`getDirectives` helpers. Occurrences of the same directive remain ordered in
+that map; use the ResGraph projection when order across different directive
+names matters.
+
+## Standard scalar specification URLs
+
+Custom scalars can emit the standard `@specifiedBy` directive and native
+`specifiedByURL` runtime property:
+
+```rescript
+@specifiedBy("https://example.com/scalars/uuid")
+@gql.scalar
+type uuid = string
+```
+
+## Runtime behavior
+
+Directive declarations only describe schema metadata. Implement behavior with
+an explicit GraphQL Tools schema transform, a Yoga or Envelop plugin, or normal
+resolver logic. This keeps the schema contract inspectable without hiding
+resolver wrapping or request-time work in an attribute.

--- a/plans/directives-and-graphql-roadmap.md
+++ b/plans/directives-and-graphql-roadmap.md
@@ -1,8 +1,8 @@
 # Directives and GraphQL capability roadmap
 
 Status: directive foundation implemented on `agent/directives-roadmap`; remaining
-directive and capability work is tracked below  
-ResGraph baseline: `origin/main` at `dc1647b` (`v1.3.0`, 2026-07-30)  
+directive and capability work is tracked below
+ResGraph baseline: `origin/main` at `dc1647b` (`v1.3.0`, 2026-07-30)
 Research date: 2026-07-31
 
 ## Executive summary

--- a/plans/directives-and-graphql-roadmap.md
+++ b/plans/directives-and-graphql-roadmap.md
@@ -1,0 +1,683 @@
+# Directives and GraphQL capability roadmap
+
+Status: directive foundation implemented on `agent/directives-roadmap`; remaining
+directive and capability work is tracked below  
+ResGraph baseline: `origin/main` at `dc1647b` (`v1.3.0`, 2026-07-30)  
+Research date: 2026-07-31
+
+## Executive summary
+
+ResGraph should treat directives as schema data, not as executable decorators.
+The compiler should understand directive definitions and ordered directive
+applications, validate them, and lower them consistently into both generated
+SDL and the generated `graphql-js` schema. Implementing directive behavior
+should remain an explicit schema-transform or server-plugin concern.
+
+The cleanest ReScript-facing design is:
+
+- Define a directive with `@gql.directive` on an abstract or record type. A
+  record models the directive's typed arguments; an abstract type defines a
+  directive with no arguments.
+- Apply a directive with repeatable `@gql.annotate` attributes whose payload is
+  a GraphQL-const-compatible ReScript record.
+- Preserve applied directives at runtime in two projections generated from the
+  same ordered IR: the ecosystem-compatible `extensions.directives` map and an
+  exact ordered list under `extensions.resgraph.appliedDirectives`.
+- Keep built-ins semantic: lower `@deprecated`, `@specifiedBy`, and inferred
+  `@oneOf` to their native `graphql-js` properties as well as correct SDL.
+- Add one shared input-value/constant-value model to the IR. Directives,
+  argument defaults, input-field defaults, descriptions, and deprecations then
+  build on the same foundation.
+
+The highest-priority work around directives is to modernize the GraphQL runtime
+contract. ResGraph's tests are pinned to `graphql@16.8.1`, generated OneOf input
+objects use the pre-standard `extensions.oneOf` convention, and the docs still
+call OneOf experimental. OneOf is part of the September 2025 GraphQL
+specification and current `graphql-js` exposes it as `isOneOf`.
+
+After directives, the biggest user-visible gaps relative to Grats are argument
+and input defaults, argument descriptions/deprecations, generic type
+materialization, derived context, non-subscription `AsyncIterable` fields for
+`@stream`, root-field shorthand, and smoother incremental schema integration.
+The biggest general GraphQL gaps are full type-system directive coverage,
+schema definitions/extensions, scalar `specifiedByURL`/`parseLiteral`, and a
+more comprehensive schema-validation/fidelity pass.
+
+### Implementation status
+
+The directive foundation delivered on this branch includes:
+
+- Typed custom directive definitions from abstract and record types, including
+  locations, repeatability, descriptions, typed arguments, defaults, and
+  deprecated arguments.
+- Ordered applications on scalars, objects, interfaces, unions, enums, enum
+  values, input objects, input fields, and output fields.
+- Shared GraphQL constant-value parsing/coercion and build-time validation for
+  definitions, locations, repeatability, arguments, and values.
+- SDL and executable-schema parity, custom directive introspection,
+  `specifiedByURL`, the GraphQL Tools `extensions.directives` convention, and
+  an exact ordered `extensions.resgraph.appliedDirectives` projection.
+
+The next directive slices are deliberately still open:
+
+- Add a schema marker for schema-level descriptions, root mappings, and
+  `SCHEMA` applications.
+- Correlate resolver source parameters with CMT output so
+  `ARGUMENT_DEFINITION` applications, defaults, descriptions, and deprecations
+  can use normal parameter syntax.
+- Finish native built-in modernization for standard OneOf, and decide whether
+  generic annotations should normalize built-ins such as `deprecated`.
+- Add directive-aware LSP/state metadata, named/multi-schema coverage, and a
+  full `graphql-js` validation/AST backstop with source-coordinate mapping.
+
+Part II remains the backlog for the Grats and broader GraphQL gaps to tackle
+after this foundation.
+
+## Part I: directive support
+
+### Goals
+
+1. Define custom directives with descriptions, typed arguments, defaults,
+   deprecated arguments, locations, and repeatability.
+2. Apply directives to every type-system location ResGraph can author:
+   `SCHEMA`, `SCALAR`, `OBJECT`, `FIELD_DEFINITION`, `ARGUMENT_DEFINITION`,
+   `INTERFACE`, `UNION`, `ENUM`, `ENUM_VALUE`, `INPUT_OBJECT`, and
+   `INPUT_FIELD_DEFINITION`.
+3. Permit definitions that include executable locations (`QUERY`, `MUTATION`,
+   `SUBSCRIPTION`, `FIELD`, fragment locations, and `VARIABLE_DEFINITION`) even
+   though ResGraph does not author executable documents.
+4. Validate names, locations, repeatability, required/unknown arguments, and
+   constant-value coercion at build time with source-located diagnostics.
+5. Preserve lexical directive order. The GraphQL specification explicitly
+   allows directive order to be significant.
+6. Keep generated SDL, introspection, and runtime metadata in agreement.
+7. Interoperate without adapters with `@graphql-tools/utils`'s
+   `getDirective(s)` functions, without giving up exact cross-directive source
+   order for ResGraph-aware consumers.
+
+### Non-goals for the first release
+
+- A magic runtime implementation attached to the directive declaration.
+  Defining `@cost`, for example, must not silently wrap resolvers.
+- A general query-directive execution engine. Users can implement query
+  directives with Yoga/Envelop plugins or `resolveInfo`.
+- Federation behavior. Directive support is a prerequisite for Federation, not
+  a complete Federation implementation.
+- Immediate replacement of ResGraph's entire schema IR with `graphql-js` AST
+  objects. Grats benefits from doing that, but ResGraph can take the useful
+  ideas without a high-risk rewrite.
+
+### Proposed authoring API
+
+#### Directive definitions
+
+A record type supplies typed directive arguments:
+
+```rescript
+/** Describes the relative execution cost of a schema element. */
+@gql.directive({
+  locations: ["FIELD_DEFINITION", "OBJECT"],
+  repeatable: true,
+})
+type cost = {
+  /** Number of credits consumed. */
+  @gql.default(1)
+  credits: int,
+}
+```
+
+This produces:
+
+```graphql
+"""Describes the relative execution cost of a schema element."""
+directive @cost(
+  """Number of credits consumed."""
+  credits: Int! = 1
+) repeatable on FIELD_DEFINITION | OBJECT
+```
+
+An abstract type defines a directive without arguments:
+
+```rescript
+@gql.directive({locations: ["FIELD_DEFINITION"]})
+type authenticated
+```
+
+The GraphQL directive name is the ReScript type name without capitalization.
+The existing `@as("...")` convention should override it. Locations use the
+spec's strings so there is no second naming scheme to learn; invalid strings
+receive a diagnostic at the attribute.
+
+Why a type rather than a function, as Grats uses:
+
+- Records are ReScript's natural data-modeling construct and match the existing
+  input-object model.
+- Record-field documentation and attributes are already retained in the CMT
+  summary. Function parameter defaults and parameter-level metadata are not.
+- A declaration that looks callable but is never called is less natural in
+  ReScript.
+- The type can be inspected without inventing a runtime value or behavior.
+
+Raw SDL is deliberately not the primary API. It would be easy to parse but
+would give up ReScript-derived input types and duplicate schema knowledge.
+
+#### Directive applications
+
+Apply a directive with an ordered, repeatable attribute:
+
+```rescript
+@gql.annotate({name: "cost", args: {credits: 3}})
+@gql.annotate({name: "authenticated"})
+@gql.field
+let viewer = (_: query, ~ctx: ResGraphContext.context): option<viewer> => {
+  loadViewer(ctx)
+}
+```
+
+The second argument is a GraphQL constant value represented with ReScript
+literals: strings, integers, floats, booleans, null, arrays, records/dicts, and
+nested combinations. Enum-looking strings are resolved against the declared
+argument type during validation, so users do not need a second enum-literal
+wrapper merely for attribute payloads.
+
+Using a structured ReScript payload instead of
+`@gql.annotate({name: "cost(credits: 3)"})` avoids introducing a second GraphQL parser
+inside the native generator and follows the existing `@gql.public({...})`
+style. The compiler still stores a GraphQL-shaped constant-value variant, not
+arbitrary ReScript expressions. Non-constant expressions are rejected.
+
+Multiple applications remain separate and retain source order:
+
+```rescript
+@gql.annotate({name: "tag", args: {name: "internal"}})
+@gql.annotate({name: "tag", args: {name: "beta"}})
+@gql.type
+type user = {
+  @gql.field id: ResGraph.id,
+}
+```
+
+#### Schema-level directives
+
+ResGraph currently has no source representation for a schema definition. Add
+an optional marker that is only needed for a schema description, custom root
+mapping, or schema directives:
+
+```rescript
+/** The public API schema. */
+@gql.annotate({
+  name: "link",
+  args: {url: "https://specs.apollo.dev/federation/v2.11"},
+})
+@gql.schema
+type schema
+```
+
+Initially the root mapping can remain conventional (`query`, `mutation`, and
+`subscription`). The marker gives `SCHEMA` annotations a clean home and leaves
+room for custom root type names later.
+
+#### Argument-level applications and metadata
+
+Full `ARGUMENT_DEFINITION` support and resolver defaults require source AST
+information that is not present in `typedFnArg`. Before freezing syntax, add a
+small spike that parses a resolver's ReScript source and correlates its
+parameters with the CMT value by location. The preferred syntax is a normal
+attribute attached to the labeled parameter, conceptually:
+
+```rescript
+let search = (
+  _: query,
+  /** Maximum number of results. */
+  @gql.annotate({name: "constraint", args: {max: 100}})
+  ~limit: int=20,
+) => {
+  // ...
+}
+```
+
+The spike must confirm exactly where the ReScript parser attaches parameter
+doc comments and attributes. If it cannot represent this without surprising
+syntax, use a field-level fallback such as
+`@gql.annotateArgument({argument: "limit", name: "constraint", args: {max: 100}})`;
+do not ship both
+forms speculatively.
+
+The actual ReScript default expression should be the source of truth for
+resolver arguments. `@gql.default(...)` is needed only where ReScript has no
+value-level default syntax, such as directive argument records and input-object
+fields.
+
+### Internal representation
+
+Add GraphQL constant values and directive data to
+`src/ml/GenerateSchemaTypes.ml` using regular variants and records:
+
+```ocaml
+type gqlConstValue =
+  | NullValue
+  | IntValue of string
+  | FloatValue of string
+  | StringValue of string
+  | BooleanValue of bool
+  | EnumValue of string
+  | ListValue of gqlConstValue list
+  | ObjectValue of (string * gqlConstValue) list
+
+type gqlDirectiveArgument = {
+  name: string;
+  value: gqlConstValue;
+  loc: Location.t;
+}
+
+type gqlAppliedDirective = {
+  name: string;
+  arguments: gqlDirectiveArgument list;
+  loc: Location.t;
+  fileUri: Uri.t;
+}
+
+type gqlDirectiveLocation =
+  | Query
+  | Mutation
+  | Subscription
+  | Field
+  | FragmentDefinition
+  | FragmentSpread
+  | InlineFragment
+  | VariableDefinition
+  | Schema
+  | Scalar
+  | Object
+  | FieldDefinition
+  | ArgumentDefinition
+  | Interface
+  | Union
+  | Enum
+  | EnumValue
+  | InputObject
+  | InputFieldDefinition
+
+type gqlInputValueDefinition = {
+  name: string;
+  typ: graphqlType;
+  description: string option;
+  defaultValue: gqlConstValue option;
+  deprecationReason: string option;
+  directives: gqlAppliedDirective list;
+  loc: Location.t;
+  fileUri: Uri.t;
+}
+
+type gqlDirectiveDefinition = {
+  name: string;
+  description: string option;
+  arguments: gqlInputValueDefinition list;
+  repeatable: bool;
+  locations: gqlDirectiveLocation list;
+  loc: Location.t;
+  fileUri: Uri.t;
+}
+```
+
+`gqlArg` should either become `gqlInputValueDefinition` plus its
+ReScript-specific `isOptionLabelled` flag, or embed one. Input-object fields can
+then use the same definition metadata while keeping their property/conversion
+information separate. This removes the current asymmetry where input fields
+reuse the output-oriented `gqlField`, while resolver arguments contain only a
+name, type, and optional-label bit.
+
+Add ordered `directives` lists to every directable IR node and add a directive
+definition table plus schema-level applied directives to `schemaState`.
+Locations must be retained on nested constant values wherever practical so a
+bad argument points to the literal, not merely the enclosing field.
+
+### Extraction
+
+`GenerateSchemaUtils.extractGqlAttribute` currently treats an unfamiliar
+`gql.*` attribute as an error and is focused on finding one declaration kind.
+Directive work should separate three concerns:
+
+1. `extractDefinitionKind`: at most one of type/interface/field/etc.
+2. `extractAppliedDirectives`: zero or more `@gql.annotate` values in lexical
+   order.
+3. Specialized metadata collectors: `@gql.implements`, authorization,
+   defaults, and schema metadata.
+
+That avoids adding more exceptions to a single `find_map` and makes repeated
+metadata predictable. The same collectors must run in both the normal and
+direct CMT generation paths.
+
+For the first slice, CMT data is sufficient for types, fields, enum values,
+input fields, and directive definitions. The source-AST index is needed for
+function argument docs/defaults/directives. Key source data by file plus
+declaration location, not only by name, so nested modules and shadowing remain
+safe.
+
+### Validation
+
+Validate before either emitter runs:
+
+- GraphQL names and reserved `__` prefixes.
+- At least one valid location per definition and no duplicate locations.
+- Definition name uniqueness, including collisions with specified directives.
+- Directive argument names/types/defaults and deprecation restrictions.
+- Application refers to a known built-in or custom directive.
+- Application location is allowed.
+- A non-repeatable directive appears no more than once at a location.
+- Arguments are unique and known; all required arguments are supplied.
+- Constant values coerce to the declared input types, recursively.
+- OneOf values/defaults obey the current specification.
+- Built-in constraints for `deprecated`, `specifiedBy`, and `oneOf`.
+
+Grats constructs GraphQL AST and reuses `graphql-js` validation. ResGraph should
+move in that direction incrementally: keep native validations for precise
+ReScript locations, add a GraphQL-document exporter from the normalized IR,
+and run a `graphql-js` SDL/schema validation pass in the JS CLI as a backstop.
+Translate errors through schema-coordinate/source metadata already related to
+the generated state file. This also catches printer drift that handwritten
+validations will miss.
+
+### Lowering built-in directives
+
+Built-ins need native runtime behavior rather than only generic metadata:
+
+| Directive | IR/source behavior | `graphql-js` lowering | SDL lowering |
+| --- | --- | --- | --- |
+| `deprecated` | Existing ReScript `@deprecated` remains preferred; generic annotation normalizes to the same semantic field | `deprecationReason` | `@deprecated(reason: ...)` |
+| `specifiedBy` | Generic annotation on a custom scalar populates the existing dormant `specifiedByUrl` slot | `specifiedByURL` on `GraphQLScalarType` | `@specifiedBy(url: ...)` |
+| `oneOf` | Inferred from `@gql.inputUnion`; no redundant user annotation | `isOneOf: true` on `GraphQLInputObjectType` | `@oneOf` |
+
+Do not store these twice as independent semantic fields and generic extensions.
+Normalize at extraction/validation, then let each emitter choose its native
+representation. Custom directives use the generic path.
+
+### Generated runtime representation
+
+Add typed bindings for `GraphQLDirective`, `DirectiveLocation`,
+`specifiedDirectives`, directive argument configs, `specifiedByURL`, `isOneOf`,
+and `extensions` on every directable `graphql-js` config.
+
+Custom definitions must be passed to the schema without dropping built-ins:
+
+```rescript
+GraphQLSchemaType.make({
+  query: get_Query(),
+  directives: [...specifiedDirectives, directive_cost],
+  types: [...],
+})
+```
+
+Applied custom directives should expose two projections derived from the same
+ordered IR:
+
+```js
+extensions: {
+  directives: {
+    cost: [{credits: 3}],
+    tag: [{name: "beta"}],
+  },
+  resgraph: {
+    appliedDirectives: [
+      {name: "cost", args: {credits: 3}},
+      {name: "tag", args: {name: "beta"}},
+    ],
+  },
+}
+```
+
+GraphQL Tools reads the directive-name map in `extensions.directives` by
+default, so existing schema-transform packages work without a ResGraph-specific
+path option. The map preserves occurrence order for one repeatable directive,
+but cannot represent exact global order when names interleave, for example
+`@tag @cost @tag`. The namespaced ordered list closes that loss. These are
+generated views, never two independently mutable sources of truth.
+
+In the longer term, a complete `astNode`/`extensionASTNodes` projection can
+offer another standards-shaped, order-preserving view. Do not emit partial AST
+nodes just for directives: consumers reasonably expect those nodes to contain
+valid kinds, names, fields, and locations.
+
+New public bindings should use concrete ReScript records rather than adding
+more `{..}`/object-creator-style APIs. Constant values should remain the
+existing safe JSON-style variants at the public boundary.
+
+### SDL emission
+
+Both emitters must consume the same IR. Add shared printers for constant values,
+input-value definitions, directive definitions, and ordered applications.
+Centralize GraphQL string escaping rather than interpolating raw descriptions
+or deprecation reasons.
+
+Do not switch the SDL dump to `graphql-js`'s `printSchema` and assume applied
+directives survive: `GraphQLSchema` has no first-class applied-directive model.
+Either keep the IR-based SDL printer or print a generated GraphQL AST/document.
+The latter is the best long-term direction because it also enables standard
+validation and escaping.
+
+### Implementation slices
+
+1. **Runtime/spec baseline**
+   - Declare `graphql` as a peer dependency and choose a tested range that
+     includes native OneOf support.
+   - Test the floor and current `graphql@16` (currently 16.14).
+   - Replace `extensions.oneOf` with `isOneOf`, remove the obsolete Envelop
+     requirement, update docs, and add introspection/coercion tests.
+
+2. **Input-value and constant-value IR**
+   - Introduce `gqlConstValue` and enriched input-value definitions.
+   - Add parsing/printing/runtime-codegen for constant literals.
+   - Use the same foundation for `@gql.default`.
+
+3. **Definitions and applications**
+   - Add `@gql.directive` and `@gql.annotate`; add optional `@gql.schema` in a
+     follow-up.
+   - Collect directives on all CMT-visible type-system locations.
+   - Add definition/application validation.
+
+4. **Executable schema and SDL parity**
+   - Extend `ResGraph__GraphQLJs.res` bindings.
+   - Emit definitions, native built-ins, the standard directive map, and the
+     ordered ResGraph projection.
+   - Emit the same information in SDL.
+   - Add a GraphQL Tools interoperability test.
+
+5. **Resolver arguments and defaults**
+   - Complete the source-AST correlation spike.
+   - Add resolver argument descriptions, defaults, deprecations, and directive
+     applications.
+   - Extend hover, state/find-definition data, and diagnostics to argument
+     coordinates.
+
+6. **Tooling and documentation**
+   - Completion for directive names, locations, and known argument names.
+   - Hover/definition for directive declarations and applications.
+   - Cache version/input updates, named-schema and multi-schema coverage.
+   - A guide that distinguishes declaration, metadata, and runtime behavior.
+
+### Directive acceptance criteria
+
+- Generated SDL parses and validates with the supported `graphql-js` floor and
+  latest v16.
+- Introspection contains specified plus custom directives, including defaults,
+  deprecated arguments, locations, and repeatability.
+- Every supported type-system application has the same names and coerced
+  arguments in SDL and via `getDirectives(schema, node)`.
+- SDL and `extensions.resgraph.appliedDirectives` preserve exact source order;
+  `extensions.directives` preserves occurrence order within each name.
+- Invalid definition, location, duplication, missing argument, extra argument,
+  and nested value cases produce source-located build diagnostics.
+- `@deprecated`, `@specifiedBy`, and `@oneOf` work through native
+  `graphql-js` properties and introspection.
+- Named schemas, include/exclude membership, cache invalidation, authorization,
+  interface inheritance, and generated ReScript compilation remain covered.
+
+## Part II: capability map
+
+### What ResGraph already does well
+
+ResGraph already covers the core implementation-first server shape:
+
+- Query, mutation, and real AsyncIterator/AsyncIterable subscriptions.
+- Object, input object, interface (including interface inheritance), union,
+  enum, custom scalar, list, nullable, and OneOf-shaped input variants.
+- Property and function resolvers with typed context and `resolveInfo`
+  injection.
+- Descriptions on most schema elements and deprecation on output/input fields
+  and enum values.
+- Direct `graphql-js` schema codegen without runtime SDL parsing.
+- Relay node/connection helpers and DataLoader bindings.
+- Multi-schema projects with include/exclude ownership.
+- Required authorization coverage with source-aware manifests/baselines.
+- Dedicated LSP/VS Code workflow, hovers/completion, schema-coordinate
+  definition lookup, stable output, and incremental generation cache.
+
+Multi-schema generation and required authorization are meaningful ResGraph
+advantages and should remain central; they are not Grats gaps to copy.
+
+### Spec and schema-fidelity gaps
+
+| Capability | ResGraph today | Recommended action | Priority |
+| --- | --- | --- | --- |
+| Custom directive definitions/applications | Foundation implemented for every CMT-visible type-system location; schema and resolver-argument applications remain | Add schema marker and source-correlated argument support | P0 follow-up |
+| Runtime access to applied directives | Standard GraphQL Tools map and exact ordered ResGraph projection implemented | Add transformation recipes and expand multi-schema coverage | Delivered/P1 docs |
+| Argument defaults | `gqlArg` explicitly has a TODO and no default slot | Parse resolver source defaults into shared input-value IR | P0 |
+| Argument descriptions/deprecations/directives | `gqlArg` only carries name/type/optional-label | Source-AST parameter metadata plus enriched input-value IR | P0 |
+| Input-field defaults | Shared constant-value parsing exists, but `gqlField` has no default slot yet | Add `@gql.default(const)` to the input-field IR, SDL, and runtime config | P1 |
+| `@specifiedBy` | Native `@specifiedBy("...")` emits SDL and `specifiedByURL` | Consider normalization through the generic annotation path | Delivered/P2 |
+| Standard OneOf | Input unions emit `extensions: {oneOf: true}` and require an obsolete validation plugin; tests pin GraphQL 16.8.1 | Upgrade runtime contract, use `isOneOf`, update introspection/coercion/docs | P0 |
+| Schema definition metadata | No schema description, directives, or custom root mapping source | Add optional `@gql.schema` marker; custom roots can follow | P1 |
+| Type-system extensions | Field functions compose object/interface fields inside one ResGraph schema, but no general schema/scalar/union/enum/input extension model or external target | Model explicit/external extensions only when driven by migration/Federation use cases | P1/P2 |
+| Full schema validation | ResGraph has targeted native checks, but duplicates substantial spec logic and still lets some errors reach runtime | Export GraphQL AST/SDL and add `graphql-js` validation with coordinate-to-source translation | P0 |
+| SDL fidelity | Handwritten interpolation has multiple drift points. Union member descriptions are documented/emitted even though GraphQL has no union-member-description construct | Parse every emitted fixture; stop emitting unsupported member descriptions; centralize escaping | P0 |
+| Scalar coercion surface | Local magic `parseValue`/`serialize`; no explicit `parseLiteral` or per-schema configuration | Add `parseLiteral` and an explicit typed scalar-config option while preserving the ergonomic module convention | P1 |
+| Custom root type names | Conventional `Query`/`Mutation`/`Subscription` only | Add through the schema marker if a concrete integration needs it | P2 |
+
+### Gaps relative to Grats
+
+| Grats capability | ResGraph status | What to do | Priority |
+| --- | --- | --- | --- |
+| Directive definitions and generic annotations | Foundation implemented with records, standard directive map, and ordered ResGraph projection | Finish schema/argument locations and tooling | P0 follow-up |
+| Resolver argument defaults and metadata | Defaults/descriptions/deprecations missing | Shared input-value IR plus source-AST parameter index | P0 |
+| Generic object/interface/union/input materialization | Annotated generic named types are not deliberately monomorphized into distinct GraphQL types | Design deterministic specialization names and cycle-safe memoized materialization; start with connections/results | P1 |
+| Derived context values, including async | One configured context type only | Add `@gql.context` provider functions, dependency graph validation, cycle detection, and per-request memoization semantics | P1 |
+| Non-subscription `AsyncIterable<T>` for `@stream` | Async iterables are only unwrapped for subscription return types | In output position, map `AsyncIterable<T>` to `[T]` while retaining iterator runtime value; document required Yoga plugin | P1 |
+| Root-field shorthand | Requires explicit root type plus unused first argument | Add `@gql.query`, `@gql.mutation`, and `@gql.subscription` function attributes that synthesize roots | P1 |
+| Nullable-by-default and semantic non-null mode | Nullability maps directly from ReScript `option`/nullable types | Do not copy blindly: ReScript is more sound than TypeScript. Revisit after generic directives, as an opt-in policy with runtime checks | P2/experimental |
+| Full scalar schema config (`serialize`, `parseValue`, `parseLiteral`) | Module-name convention supports two hooks | Add missing hook and explicit config escape hatch; retain zero-config inference | P1 |
+| Incremental schema migration | Possible via `mergeSchemas`, but current guide requires duplicated types and a copy-pasted compatibility plugin | Ship/test the compatibility transform or emit a resolver map/external-type model; make field-level migration a supported path | P1 |
+| Resolver-map output | No equivalent | Consider after migration requirements are concrete; executable schema remains the default | P2 |
+| Emitted metadata | ResGraph already emits state/definition and authorization metadata | Extend the existing state format with directives/arguments/source coordinates instead of adding a parallel artifact | P1 |
+| Generated client enum module | ReScript variants already are runtime/client-usable in the authoring language | No direct port needed; document client-codegen integration instead | Not needed |
+| `--fix` and code actions | Diagnostics/completion/hover exist, but no general fix workflow | Add focused fixes for attribute spelling, obsolete OneOf setup, and safe migrations after syntax stabilizes | P2 |
+| Schema headers/config schema | Limited output customization; TODO includes config JSON schema | Add a JSON Schema and `check` command before cosmetic header options | P2 |
+
+### Broader GraphQL ecosystem opportunities
+
+These are not all core compiler obligations. The recommended response is often
+an interoperable hook or documented integration rather than built-in policy.
+
+| Area | Missing piece | Recommended response | Priority |
+| --- | --- | --- | --- |
+| Apollo Federation/subgraphs | No schema `@link`, federation directives, entity union/reference resolver, or subgraph SDL workflow | Directives/schema annotations first; then a separate `ResGraphFederation` layer with entity types/resolvers and conformance fixtures | P1/P2 |
+| Schema transforms and policy directives | Applied metadata is unavailable to standard transformers | Standard directive map plus ordered projection and examples for cost, cache, auth, and formatting transforms | P0/P1 |
+| Incremental delivery | Subscriptions work, but non-subscription async list fields do not model `@stream`; `@defer` is server/runtime driven | Add AsyncIterable list inference and Yoga integration tests; avoid owning transport protocol | P1 |
+| Persisted operations, complexity limits, tracing, response caching | Not compiler/type-system features | Improve Yoga/Envelop bindings and recipes; directives can carry static cost/cache metadata | P2/docs |
+| Scalar ecosystem | No specification URLs and a narrower coercion API | `specifiedBy`, `parseLiteral`, scalar registry examples, and typed external configs | P0/P1 |
+| External schemas/stitching | Merge path requires compatibility glue and duplicate definitions | Ship the glue, test `mergeSchemas`, then evaluate external type placeholders/resolver-map output | P1 |
+| Emerging nullability | No semantic-null metadata or nullability-assertion experiments | Build on generic directives; keep opt-in and track the active RFC rather than hard-coding draft syntax | Experimental |
+| Client/tooling interoperability | State is ResGraph-specific and SDL can omit metadata | Valid SDL/AST, stable schema coordinates, directive extensions, and documented GraphQL Code Generator/Relay flows | P1 |
+
+### Prioritized roadmap
+
+#### P0: make the schema representation current and trustworthy
+
+1. Declare/test the `graphql` peer range and modernize OneOf.
+2. Complete the new constant-value/input-value foundation for resolver
+   argument metadata.
+3. Finish schema/argument directive locations and native OneOf lowering.
+4. Add SDL/executable parity tests and a `graphql-js` validation backstop.
+5. Fix invalid/non-standard SDL emission, beginning with union member
+   descriptions and literal escaping.
+
+This group should land before building Federation or more directive-based
+features. Otherwise each new feature adds another one-off metadata path.
+
+#### P1: close the practical Grats gaps
+
+1. Argument/input defaults, descriptions, deprecations, and annotations.
+2. Root-field shorthand.
+3. Non-subscription AsyncIterable/list support for `@stream`.
+4. Generic type specialization for high-value patterns.
+5. Derived context providers with explicit memoization behavior.
+6. Full scalar coercion/configuration.
+7. Supported schema-merging compatibility and external-schema migration tests.
+8. Directive-aware tooling/state metadata.
+
+#### P2: ecosystem breadth and polish
+
+1. Federation as an optional layer.
+2. Resolver-map output if migration users need it.
+3. Opt-in semantic nullability experiments.
+4. CLI `check`, config JSON Schema, and safe code actions.
+5. Custom root names and broader explicit type extensions when a real use case
+   requires them.
+
+### What not to copy from Grats verbatim
+
+- Do not use a function declaration for a directive merely because Grats does;
+  a record/abstract type fits ReScript and the available metadata better.
+- Do not put directive data only in a private namespace. Emit the GraphQL Tools
+  map for interoperability and keep only the extra cross-name ordering view
+  under `extensions.resgraph`.
+- Do not make directive declarations execute implicitly. Runtime behavior must
+  be an explicit transform/plugin so ordering and server lifecycle are visible.
+- Do not adopt nullable-by-default as a default merely to match Grats. Its
+  trade-off is strongly influenced by TypeScript's soundness and common
+  GraphQL error policy.
+- Do not rewrite the whole compiler around GraphQL AST in one step. First add a
+  GraphQL-shaped boundary and validation/export path, then migrate internals
+  only where it removes real duplication.
+
+## Source trail
+
+Local ResGraph areas audited:
+
+- `src/ml/GenerateSchemaTypes.ml` — schema IR; minimal `gqlArg`; dormant
+  `specifiedByUrl`.
+- `src/ml/GenerateSchemaUtils.ml` — GraphQL attribute extraction and schema
+  registration; hard-coded `specifiedByUrl = None`.
+- `src/ml/GenerateSchema.ml` — CMT traversal, type inference, resolver argument
+  mapping, and subscription-only async iterable inference.
+- `src/ml/GenerateSchemaValidation.ml` — native schema validation.
+- `src/ml/GenerateSchemaTypePrinters.ml` — executable `graphql-js` codegen and
+  hard-coded `extensions.oneOf`.
+- `src/ml/GenerateSchemaSDL.ml` — separate handwritten SDL emitter.
+- `src/res/ResGraph__GraphQLJs.res` — runtime constructor/config bindings.
+- `tests/src/AppCustomScalars.res` — currently ignored `@specifiedBy` fixture.
+- `TODO.md`, docs, generated fixtures, multi-schema tests, and authorization
+  fixtures.
+
+External primary references:
+
+- GraphQL September 2025 specification:
+  <https://spec.graphql.org/September2025/>
+- Accepted OneOf RFC:
+  <https://rfcs.graphql.org/rfcs/825/>
+- `graphql-js` releases:
+  <https://github.com/graphql/graphql-js/releases>
+- Grats directive definitions:
+  <https://grats.capt.dev/docs/docblock-tags/directive-definitions>
+- Grats directive annotations and runtime representation:
+  <https://grats.capt.dev/docs/docblock-tags/directive-annotations>
+- Grats changelog and configuration:
+  <https://grats.capt.dev/docs/changelog/>
+  <https://grats.capt.dev/docs/getting-started/configuration>
+- Grats generics, derived context, and stream support:
+  <https://grats.capt.dev/docs/guides/generics/>
+  <https://grats.capt.dev/docs/docblock-tags/context/>
+  <https://grats.capt.dev/docs/guides/stream/>
+- GraphQL Tools schema directive convention:
+  <https://the-guild.dev/graphql/tools/docs/schema-directives>
+- GraphQL Tools implementation of directive-extension lookup:
+  <https://github.com/ardatan/graphql-tools/blob/master/packages/utils/src/getDirectiveExtensions.ts>

--- a/src/ml/GenerateSchema.ml
+++ b/src/ml/GenerateSchema.ml
@@ -8,9 +8,14 @@ let variantCasesToEnumValues ~schemaState ~(env : SharedTypes.QueryEnv.t)
   |> List.filter_map (fun (case : SharedTypes.Constructor.t) ->
       match case.args with
       | Args [] ->
+        let enumName = case.typeDecl |> fst |> capitalizeFirstChar in
+        let value = nameFromAttribute case.attributes ~default:case.cname.txt in
+        registerDirectiveApplications
+          ~target:(DirectiveEnumValue {enumName; valueName = value})
+          ~attributes:case.attributes ~schemaState ~env;
         Some
           {
-            value = nameFromAttribute case.attributes ~default:case.cname.txt;
+            value;
             description = case.attributes |> attributesToDocstring;
             deprecationReason = case.deprecated;
             loc = case.cname.loc;
@@ -848,6 +853,11 @@ and inputObjectFieldsOfRecordFields ~objectTypeName ~env ~debug ~schemaState
                };
         None
       | Some typ ->
+        registerDirectiveApplications
+          ~target:
+            (DirectiveInputFieldDefinition
+               {inputObjectName = objectTypeName; fieldName = name})
+          ~attributes:field.attributes ~schemaState ~env;
         Some
           {
             name;
@@ -862,6 +872,62 @@ and inputObjectFieldsOfRecordFields ~objectTypeName ~env ~debug ~schemaState
             onType = None;
             inheritedFromInterface = None;
           })
+
+and directiveArgumentsOfRecordFields ~directiveName ~env ~debug ~schemaState
+    ~(full : SharedTypes.full) (fields : SharedTypes.field list) =
+  let rec isInputType = function
+    | List inner | Nullable inner | RescriptNullable inner -> isInputType inner
+    | Scalar _ | GraphQLInputObject _ | GraphQLInputUnion _ | GraphQLEnum _
+    | GraphQLScalar _ ->
+      true
+    | EmptyPayload | InjectContext | InjectInfo | InjectInterfaceTypename _
+    | GraphQLObjectType _ | GraphQLUnion _ | GraphQLInterface _ ->
+      false
+  in
+  fields
+  |> List.filter_map (fun (field : SharedTypes.field) ->
+      let name = nameFromAttribute field.attributes ~default:field.fname.txt in
+      match
+        findGraphQLType field.typ ~debug ~loc:field.fname.loc ~full ~env
+          ~schemaState
+          ~typeContext:
+            (ArgumentType
+               {
+                 fieldParentTypeName = "@" ^ directiveName;
+                 fieldName = directiveName;
+                 argumentName = name;
+               })
+      with
+      | Some typ when isInputType typ ->
+        registerDirectiveApplications
+          ~target:
+            (DirectiveDirectiveArgumentDefinition
+               {directiveName; argumentName = name})
+          ~attributes:field.attributes ~schemaState ~env;
+        Some
+          {
+            name;
+            typ;
+            description = field.attributes |> attributesToDocstring;
+            defaultValue =
+              field.attributes |> defaultValueFromAttributes ~schemaState ~env;
+            deprecationReason = field.deprecated;
+            loc = field.fname.loc;
+          }
+      | Some _ ->
+        schemaState
+        |> addDiagnostic
+             ~diagnostic:
+               {
+                 fileUri = env.file.uri;
+                 loc = field.fname.loc;
+                 message =
+                   Printf.sprintf
+                     "Directive argument `%s` must use a GraphQL input type."
+                     name;
+               };
+        None
+      | None -> None)
 
 and variantCasesToUnionValues ~env ~debug ~schemaState ~full ~ownerName
     (cases : SharedTypes.Constructor.t list) =
@@ -949,6 +1015,12 @@ and variantCasesToInputUnionValues ~env ~debug ~schemaState ~full ~ownerName
     (cases : SharedTypes.Constructor.t list) =
   cases
   |> List.filter_map (fun (case : SharedTypes.Constructor.t) ->
+      let fieldName = uncapitalizeFirstChar case.cname.txt in
+      registerDirectiveApplications
+        ~target:
+          (DirectiveInputFieldDefinition
+             {inputObjectName = ownerName; fieldName})
+        ~attributes:case.attributes ~schemaState ~env;
       match case.args with
       | InlineRecord fields ->
         let syntheticTypeName = ownerName ^ case.cname.txt in
@@ -971,7 +1043,7 @@ and variantCasesToInputUnionValues ~env ~debug ~schemaState ~full ~ownerName
         let member : gqlInputUnionMember =
           {
             typ = GraphQLInputObject {displayName; id};
-            fieldName = uncapitalizeFirstChar case.cname.txt;
+            fieldName;
             loc = case.cname.loc;
             description = case.attributes |> ProcessAttributes.findDocAttribute;
             constructorName = case.cname.txt;
@@ -982,7 +1054,7 @@ and variantCasesToInputUnionValues ~env ~debug ~schemaState ~full ~ownerName
         Some
           {
             typ = EmptyPayload;
-            fieldName = uncapitalizeFirstChar case.cname.txt;
+            fieldName;
             loc = case.cname.loc;
             description = case.attributes |> ProcessAttributes.findDocAttribute;
             constructorName = case.cname.txt;
@@ -999,7 +1071,7 @@ and variantCasesToInputUnionValues ~env ~debug ~schemaState ~full ~ownerName
           Some
             {
               typ;
-              fieldName = uncapitalizeFirstChar case.cname.txt;
+              fieldName;
               loc = case.cname.loc;
               description =
                 case.attributes |> ProcessAttributes.findDocAttribute;
@@ -1077,6 +1149,11 @@ and objectTypeFieldsOfRecordFields ~objectTypeName ~env ~schemaState ~debug
                };
         None
       | Some typ ->
+        registerDirectiveApplications
+          ~target:
+            (DirectiveFieldDefinition
+               {parentTypeName = objectTypeName; fieldName = name})
+          ~attributes:field.attributes ~schemaState ~env;
         Some
           {
             name;
@@ -1127,6 +1204,11 @@ and objectTypeFieldsOfInlineRecordFields ~objectTypeName ~env ~schemaState
                };
         None
       | Some typ ->
+        registerDirectiveApplications
+          ~target:
+            (DirectiveFieldDefinition
+               {parentTypeName = objectTypeName; fieldName = name})
+          ~attributes:field.attributes ~schemaState ~env;
         Some
           {
             name;
@@ -1281,6 +1363,44 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
         let gqlImplementsAttributes =
           attributes |> extractGqlImplementsAttributes ~schemaState ~env
         in
+        let registerDirectives target =
+          registerDirectiveApplications ~target ~attributes ~schemaState ~env
+        in
+        let registerDirectiveDefinition arguments =
+          match directiveConfigFromAttributes ~schemaState ~env attributes with
+          | Some (Some {locations; repeatable}) ->
+            let name = nameFromAttribute attributes ~default:item.name in
+            if Hashtbl.mem schemaState.directiveDefinitions name then
+              schemaState
+              |> addDiagnostic
+                   ~diagnostic:
+                     {
+                       loc = item.loc;
+                       fileUri = env.file.uri;
+                       message =
+                         Printf.sprintf
+                           "A directive named `@%s` has already been defined."
+                           name;
+                     }
+            else
+              Hashtbl.add schemaState.directiveDefinitions name
+                {
+                  name;
+                  description = attributesToDocstring attributes;
+                  arguments;
+                  locations;
+                  repeatable;
+                  typeLocation =
+                    {
+                      fileName = env.file.moduleName;
+                      modulePath = List.rev modulePath;
+                      typeName = item.name;
+                      loc = item.loc;
+                      fileUri = env.file.uri;
+                    };
+                }
+          | Some None | None -> ()
+        in
         (if List.length gqlImplementsAttributes > 0 then
            match (item.kind, gqlAttribute) with
            | Type ({kind = Record _}, _), Some (ObjectType | Interface) -> ()
@@ -1314,6 +1434,13 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
           traverseStructure ~implStructure
             ~modulePath:(intfStructure.name :: modulePath)
             ~schemaState ~env ~full ~debug intfStructure
+        | Type ({kind = Abstract None; _}, _), Some Directive ->
+          registerDirectiveDefinition []
+        | Type ({kind = Record fields; _}, _), Some Directive ->
+          let directiveName = nameFromAttribute attributes ~default:item.name in
+          registerDirectiveDefinition
+            (directiveArgumentsOfRecordFields ~directiveName ~env ~debug
+               ~schemaState ~full fields)
         | ( Type
               ( {
                   name = "query" | "mutation" | "subscription";
@@ -1328,6 +1455,7 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
           (* @gql.type type subscription *)
           let id = item.name in
           let displayName = capitalizeFirstChar item.name in
+          registerDirectives (DirectiveObject displayName);
           registerAuthorizationAttributes ~coordinate:displayName
             ~allowPublic:false ~attributes ~schemaState ~env;
           noticeObjectType ~env ~loc:decl.type_loc ~schemaState
@@ -1339,6 +1467,7 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
           (* @gql.type type someType = {...} *)
           let id = item.name in
           let displayName = capitalizeFirstChar item.name in
+          registerDirectives (DirectiveObject displayName);
           registerAuthorizationAttributes ~coordinate:displayName
             ~allowPublic:false ~attributes ~schemaState ~env;
           noticeObjectType ~env ~loc:decl.type_loc ~schemaState
@@ -1353,6 +1482,7 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
           (* @gql.inputObject type someInputObject = {...} *)
           let id = item.name in
           let displayName = capitalizeFirstChar item.name in
+          registerDirectives (DirectiveInputObject displayName);
           addInputObject id ~schemaState ~debug ~makeInputObject:(fun () ->
               {
                 id;
@@ -1371,6 +1501,7 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
           (* @gql.interface type hasName = {...} *)
           let id = item.name in
           let displayName = capitalizeFirstChar item.name in
+          registerDirectives (DirectiveInterface displayName);
           registerAuthorizationAttributes ~coordinate:displayName
             ~allowPublic:false ~attributes ~schemaState ~env;
           addInterface id ~schemaState ~debug ~makeInterface:(fun () ->
@@ -1390,10 +1521,12 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
         | Type (({kind = Variant cases} as item), _), Some Enum ->
           (* @gql.enum type someEnum = Online | Offline | Idle *)
           (* TODO: Can inline all type locs *)
+          let displayName = capitalizeFirstChar item.name in
+          registerDirectives (DirectiveEnum displayName);
           addEnum item.name ~schemaState ~debug ~makeEnum:(fun () ->
               {
                 id = item.name;
-                displayName = capitalizeFirstChar item.name;
+                displayName;
                 values = variantCasesToEnumValues ~schemaState ~env cases;
                 description = attributes |> attributesToDocstring;
                 typeLocation =
@@ -1404,6 +1537,7 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
         | Type (({kind = Variant cases} as item), _), Some Union ->
           (* @gql.union type userOrGroup = User(user) | Group(group) *)
           let displayName = capitalizeFirstChar item.name in
+          registerDirectives (DirectiveUnion displayName);
           addUnion item.name
             ~makeUnion:(fun () ->
               {
@@ -1423,6 +1557,7 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
         | Type (({kind = Variant cases} as item), _), Some InputUnion ->
           (* @gql.inputUnion type location = Coordinates(coordinates) | Address(address) *)
           let displayName = capitalizeFirstChar item.name in
+          registerDirectives (DirectiveInputObject displayName);
           addInputUnion item.name
             ~makeInputUnion:(fun () ->
               {
@@ -1441,6 +1576,10 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
           (* module Timestamp = { @gql.scalar type t = string } *)
           (* module Timestamp: {@gql.scalar type t } = { type t = string } *)
           let typeName = modulePath |> List.hd in
+          registerDirectives (DirectiveScalar typeName);
+          let specifiedByUrl =
+            specifiedByUrlFromAttributes ~schemaState ~env attributes
+          in
           let typeLoc =
             {
               fileName = env.file.moduleName;
@@ -1496,8 +1635,8 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
             (* Has parsers, always add them *)
             addScalar typeName
               ?description:(attributes |> attributesToDocstring)
-              ~encoderDecoderLoc:typeLoc ~typeLocation:typeLoc ~schemaState
-              ~debug
+              ?specifiedByUrl ~encoderDecoderLoc:typeLoc ~typeLocation:typeLoc
+              ~schemaState ~debug
           | true, false, true | true, true, false | true, false, false ->
             (* Needs parsing, but missing one of the assets *)
             schemaState
@@ -1522,15 +1661,21 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
             (* Does not need parsing, and don't have assets *)
             addScalar typeName
               ?description:(attributes |> attributesToDocstring)
-              ~typeLocation:typeLoc ~schemaState ~debug)
+              ?specifiedByUrl ~typeLocation:typeLoc ~schemaState ~debug)
         | Type (({kind = Abstract (Some (path, typs))} as item), _), Some Scalar
           -> (
           (* @gql.scalar type someScalar = string *)
+          let displayName = capitalizeFirstChar item.name in
+          registerDirectives (DirectiveScalar displayName);
+          let specifiedByUrl =
+            specifiedByUrlFromAttributes ~schemaState ~env attributes
+          in
           let asTypExpr = Ctype.newconstr path typs in
           match validateCustomScalar ~env ~package:full.package asTypExpr with
           | DoesNotNeedParsing ->
             addScalar item.name
               ?description:(attributes |> attributesToDocstring)
+              ?specifiedByUrl
               ~typeLocation:
                 (findTypeLocation ~loc:item.decl.type_loc ~env ~schemaState
                    ~expectedType:Scalar item.name)
@@ -1593,6 +1738,11 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
                             functions adding fields to interfaces."
                            name;
                      });
+            registerDirectiveApplications
+              ~target:
+                (DirectiveFieldDefinition
+                   {parentTypeName = displayName; fieldName = item.name})
+              ~attributes ~schemaState ~env;
             let field =
               {
                 loc = item.loc;
@@ -1654,6 +1804,11 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
                            (interfaceHelperModuleForId helperModule id);
                      }
             | _ -> ());
+            registerDirectiveApplications
+              ~target:
+                (DirectiveFieldDefinition
+                   {parentTypeName = displayName; fieldName = item.name})
+              ~attributes ~schemaState ~env;
             let field =
               {
                 loc = item.loc;
@@ -1793,6 +1948,16 @@ and traverseStructure ?(modulePath = []) ?implStructure ?originModule
                       "This type is annotated with @gql.interface, but is not \
                        a record. Only records can represent GraphQL \
                        interfaces.";
+                }
+          | Some Directive ->
+            add
+              ~diagnostic:
+                {
+                  baseDiagnostic with
+                  message =
+                    "This type is annotated with @gql.directive, but is not an \
+                     abstract type or record. Directive records define typed \
+                     arguments.";
                 }
           | Some (InterfaceResolver _) ->
             add

--- a/src/ml/GenerateSchemaDirect.ml
+++ b/src/ml/GenerateSchemaDirect.ml
@@ -209,6 +209,8 @@ let generateSchemaDirect ~printToStdOut ~writeStateFile ~sourceFolder ~debug
                  inputUnions = Hashtbl.create 10;
                  interfaces = Hashtbl.create 10;
                  scalars = Hashtbl.create 10;
+                 directiveDefinitions = Hashtbl.create 10;
+                 appliedDirectives = Hashtbl.create 50;
                  authorizationConfig;
                  authorizationDeclarations = Hashtbl.create 50;
                  authorizationPlans = Hashtbl.create 50;

--- a/src/ml/GenerateSchemaDirectiveUtils.ml
+++ b/src/ml/GenerateSchemaDirectiveUtils.ml
@@ -1,0 +1,77 @@
+open GenerateSchemaTypes
+
+let locationToString = function
+  | LocationQuery -> "QUERY"
+  | LocationMutation -> "MUTATION"
+  | LocationSubscription -> "SUBSCRIPTION"
+  | LocationField -> "FIELD"
+  | LocationFragmentDefinition -> "FRAGMENT_DEFINITION"
+  | LocationFragmentSpread -> "FRAGMENT_SPREAD"
+  | LocationInlineFragment -> "INLINE_FRAGMENT"
+  | LocationVariableDefinition -> "VARIABLE_DEFINITION"
+  | LocationSchema -> "SCHEMA"
+  | LocationScalar -> "SCALAR"
+  | LocationObject -> "OBJECT"
+  | LocationFieldDefinition -> "FIELD_DEFINITION"
+  | LocationArgumentDefinition -> "ARGUMENT_DEFINITION"
+  | LocationInterface -> "INTERFACE"
+  | LocationUnion -> "UNION"
+  | LocationEnum -> "ENUM"
+  | LocationEnumValue -> "ENUM_VALUE"
+  | LocationInputObject -> "INPUT_OBJECT"
+  | LocationInputFieldDefinition -> "INPUT_FIELD_DEFINITION"
+
+let locationOfString = function
+  | "QUERY" -> Some LocationQuery
+  | "MUTATION" -> Some LocationMutation
+  | "SUBSCRIPTION" -> Some LocationSubscription
+  | "FIELD" -> Some LocationField
+  | "FRAGMENT_DEFINITION" -> Some LocationFragmentDefinition
+  | "FRAGMENT_SPREAD" -> Some LocationFragmentSpread
+  | "INLINE_FRAGMENT" -> Some LocationInlineFragment
+  | "VARIABLE_DEFINITION" -> Some LocationVariableDefinition
+  | "SCHEMA" -> Some LocationSchema
+  | "SCALAR" -> Some LocationScalar
+  | "OBJECT" -> Some LocationObject
+  | "FIELD_DEFINITION" -> Some LocationFieldDefinition
+  | "ARGUMENT_DEFINITION" -> Some LocationArgumentDefinition
+  | "INTERFACE" -> Some LocationInterface
+  | "UNION" -> Some LocationUnion
+  | "ENUM" -> Some LocationEnum
+  | "ENUM_VALUE" -> Some LocationEnumValue
+  | "INPUT_OBJECT" -> Some LocationInputObject
+  | "INPUT_FIELD_DEFINITION" -> Some LocationInputFieldDefinition
+  | _ -> None
+
+let locationForTarget = function
+  | DirectiveSchema -> LocationSchema
+  | DirectiveScalar _ -> LocationScalar
+  | DirectiveObject _ -> LocationObject
+  | DirectiveFieldDefinition _ -> LocationFieldDefinition
+  | DirectiveArgumentDefinition _ -> LocationArgumentDefinition
+  | DirectiveDirectiveArgumentDefinition _ -> LocationArgumentDefinition
+  | DirectiveInterface _ -> LocationInterface
+  | DirectiveUnion _ -> LocationUnion
+  | DirectiveEnum _ -> LocationEnum
+  | DirectiveEnumValue _ -> LocationEnumValue
+  | DirectiveInputObject _ -> LocationInputObject
+  | DirectiveInputFieldDefinition _ -> LocationInputFieldDefinition
+
+let targetToString = function
+  | DirectiveSchema -> "schema"
+  | DirectiveScalar name
+  | DirectiveObject name
+  | DirectiveInterface name
+  | DirectiveUnion name
+  | DirectiveEnum name
+  | DirectiveInputObject name ->
+    name
+  | DirectiveFieldDefinition {parentTypeName; fieldName} ->
+    parentTypeName ^ "." ^ fieldName
+  | DirectiveArgumentDefinition {parentTypeName; fieldName; argumentName} ->
+    Printf.sprintf "%s.%s(%s:)" parentTypeName fieldName argumentName
+  | DirectiveDirectiveArgumentDefinition {directiveName; argumentName} ->
+    Printf.sprintf "@%s(%s:)" directiveName argumentName
+  | DirectiveEnumValue {enumName; valueName} -> enumName ^ "." ^ valueName
+  | DirectiveInputFieldDefinition {inputObjectName; fieldName} ->
+    inputObjectName ^ "." ^ fieldName

--- a/src/ml/GenerateSchemaSDL.ml
+++ b/src/ml/GenerateSchemaSDL.ml
@@ -56,7 +56,70 @@ let printDeprecatedDirective deprecationReason =
     Printf.sprintf " @deprecated(reason: \"%s\")" deprecationReason
   | None -> ""
 
-let printFields fields =
+let rec constValueToString = function
+  | ConstNull -> "null"
+  | ConstInt value | ConstFloat value | ConstEnum value -> value
+  | ConstString value -> Printf.sprintf "\"%s\"" (Json.escape value)
+  | ConstBoolean value -> if value then "true" else "false"
+  | ConstList values ->
+    Printf.sprintf "[%s]"
+      (values |> List.map constValueToString |> String.concat ", ")
+  | ConstObject fields ->
+    Printf.sprintf "{%s}"
+      (fields
+      |> List.map (fun (name, value) ->
+          Printf.sprintf "%s: %s" name (constValueToString value))
+      |> String.concat ", ")
+
+let printDirectiveApplication (application : gqlDirectiveApplication) =
+  Printf.sprintf " @%s%s" application.name
+    (match application.arguments with
+    | [] -> ""
+    | arguments ->
+      Printf.sprintf "(%s)"
+        (arguments
+        |> List.map (fun (name, value) ->
+            Printf.sprintf "%s: %s" name (constValueToString value))
+        |> String.concat ", "))
+
+let printDirectiveApplications schemaState target =
+  GenerateSchemaUtils.directivesForTarget schemaState target
+  |> List.map printDirectiveApplication
+  |> String.concat ""
+
+let printDirectiveDefinition schemaState (definition : gqlDirectiveDefinition) =
+  let arguments =
+    match definition.arguments with
+    | [] -> ""
+    | arguments ->
+      Printf.sprintf "(\n%s\n)"
+        (arguments
+        |> List.map (fun (argument : gqlDirectiveArgument) ->
+            Printf.sprintf "%s  %s: %s%s%s"
+              (printDescription argument.description 2)
+              argument.name
+              (graphqlTypeToString argument.typ)
+              (match argument.defaultValue with
+              | None -> ""
+              | Some value -> " = " ^ constValueToString value)
+              (printDeprecatedDirective argument.deprecationReason
+              ^ printDirectiveApplications schemaState
+                  (DirectiveDirectiveArgumentDefinition
+                     {
+                       directiveName = definition.name;
+                       argumentName = argument.name;
+                     })))
+        |> String.concat "\n")
+  in
+  Printf.sprintf "%sdirective @%s%s%s on %s"
+    (printDescription definition.description 0)
+    definition.name arguments
+    (if definition.repeatable then " repeatable" else "")
+    (definition.locations
+    |> List.map GenerateSchemaDirectiveUtils.locationToString
+    |> String.concat " | ")
+
+let printFields ~schemaState ~parentTypeName ~input fields =
   fields
   |> List.map (fun (f : gqlField) ->
       let args = GenerateSchemaUtils.onlyPrintableArgs f.args in
@@ -71,7 +134,13 @@ let printFields fields =
              |> String.concat ", ")
          else "")
         (graphqlTypeToString f.typ)
-        (printDeprecatedDirective f.deprecationReason))
+        (printDeprecatedDirective f.deprecationReason
+        ^ printDirectiveApplications schemaState
+            (if input then
+               DirectiveInputFieldDefinition
+                 {inputObjectName = parentTypeName; fieldName = f.name}
+             else DirectiveFieldDefinition {parentTypeName; fieldName = f.name})
+        ))
   |> String.concat "\n"
 
 let printSourceLoc = false
@@ -91,50 +160,65 @@ let printSourceLocDirective (typeLocation : typeLocation option) =
         (start |> fst) (start |> snd) (end_ |> fst) (end_ |> snd)
     | _ -> ""
 
-let printInputObject (input : gqlInputObjectType) =
-  Printf.sprintf "%sinput %s%s {\n%s\n}"
+let printInputObject schemaState (input : gqlInputObjectType) =
+  Printf.sprintf "%sinput %s%s%s {\n%s\n}"
     (printDescription input.description 0)
     input.displayName
     (printSourceLocDirective
        (match input.typeLocation with
        | Some typeLocation -> Some (Concrete typeLocation)
        | None -> None))
-    (printFields input.fields)
+    (printDirectiveApplications schemaState
+       (DirectiveInputObject input.displayName))
+    (printFields ~schemaState ~parentTypeName:input.displayName ~input:true
+       input.fields)
 
-let printInputUnion (input : gqlInputUnionType) =
+let printInputUnion schemaState (input : gqlInputUnionType) =
   let input = inputUnionToInputObj input in
-  Printf.sprintf "%sinput %s%s @oneOf {\n%s\n}"
+  Printf.sprintf "%sinput %s%s @oneOf%s {\n%s\n}"
     (printDescription input.description 0)
     input.displayName
     (printSourceLocDirective
        (match input.typeLocation with
        | Some typeLocation -> Some (Concrete typeLocation)
        | None -> None))
-    (printFields input.fields)
+    (printDirectiveApplications schemaState
+       (DirectiveInputObject input.displayName))
+    (printFields ~schemaState ~parentTypeName:input.displayName ~input:true
+       input.fields)
 
-let printScalar (scalar : gqlScalar) =
-  Printf.sprintf "%sscalar %s"
+let printScalar schemaState (scalar : gqlScalar) =
+  Printf.sprintf "%sscalar %s%s%s"
     (printDescription scalar.description 0)
     scalar.displayName
+    (match scalar.specifiedByUrl with
+    | None -> ""
+    | Some url -> Printf.sprintf " @specifiedBy(url: \"%s\")" (Json.escape url))
+    (printDirectiveApplications schemaState (DirectiveScalar scalar.displayName))
 
-let printEnum (enum : gqlEnum) =
-  Printf.sprintf "%senum %s%s {\n%s\n}"
+let printEnum schemaState (enum : gqlEnum) =
+  Printf.sprintf "%senum %s%s%s {\n%s\n}"
     (printDescription enum.description 0)
     enum.displayName
     (printSourceLocDirective (Some enum.typeLocation))
+    (printDirectiveApplications schemaState (DirectiveEnum enum.displayName))
     (enum.values
     |> List.map (fun (v : gqlEnumValue) ->
         Printf.sprintf "%s  %s%s"
           (printDescription v.description 2)
           v.value
-          (printDeprecatedDirective v.deprecationReason))
+          (printDeprecatedDirective v.deprecationReason
+          ^ printDirectiveApplications schemaState
+              (DirectiveEnumValue
+                 {enumName = enum.displayName; valueName = v.value})))
     |> String.concat "\n")
 
-let printUnion (union : gqlUnion) =
-  Printf.sprintf "%sunion %s%s =\n%s\n"
+let printUnion schemaState (union : gqlUnion) =
+  Printf.sprintf "%sunion %s%s%s =\n%s\n"
     (printDescription union.description 0)
     union.displayName
     (printSourceLocDirective (Some union.typeLocation))
+    (printDirectiveApplications schemaState (DirectiveUnion union.displayName))
     (union.types
     |> List.map (fun (v : gqlUnionMember) ->
         Printf.sprintf "  | %s%s"
@@ -144,21 +228,26 @@ let printUnion (union : gqlUnion) =
           v.displayName)
     |> String.concat "\n")
 
-let printInterface (intf : gqlInterface) =
-  Printf.sprintf "%sinterface %s%s%s {\n%s\n}"
+let printInterface schemaState (intf : gqlInterface) =
+  Printf.sprintf "%sinterface %s%s%s%s {\n%s\n}"
     (printDescription intf.description 0)
     intf.displayName
     (printImplements intf.interfaces)
     (printSourceLocDirective (Some (Concrete intf.typeLocation)))
-    (printFields intf.fields)
+    (printDirectiveApplications schemaState
+       (DirectiveInterface intf.displayName))
+    (printFields ~schemaState ~parentTypeName:intf.displayName ~input:false
+       intf.fields)
 
-let printObjectType (typ : gqlObjectType) =
-  Printf.sprintf "%stype %s%s%s {\n%s\n}"
+let printObjectType schemaState (typ : gqlObjectType) =
+  Printf.sprintf "%stype %s%s%s%s {\n%s\n}"
     (printDescription typ.description 0)
     typ.displayName
     (printImplements typ.interfaces)
     (printSourceLocDirective typ.typeLocation)
-    (printFields typ.fields)
+    (printDirectiveApplications schemaState (DirectiveObject typ.displayName))
+    (printFields ~schemaState ~parentTypeName:typ.displayName ~input:false
+       typ.fields)
 
 let printSchemaSDL (schemaState : schemaState) =
   let code = Buffer.create 16384 in
@@ -175,31 +264,35 @@ let printSchemaSDL (schemaState : schemaState) =
        UNION | INPUT_OBJECT | INPUT_FIELD_DEFINITION | INTERFACE | SCALAR | \
        ARGUMENT_DEFINITION";
 
+  schemaState.directiveDefinitions
+  |> iterHashtblAlphabetically (fun _ definition ->
+      addSection (printDirectiveDefinition schemaState definition));
+
   schemaState.scalars
   |> iterHashtblAlphabetically (fun _ (scalar : gqlScalar) ->
-      addSection (printScalar scalar));
+      addSection (printScalar schemaState scalar));
 
   schemaState.enums
   |> iterHashtblAlphabetically (fun _name (enum : gqlEnum) ->
-      addSection (printEnum enum));
+      addSection (printEnum schemaState enum));
 
   schemaState.unions
   |> iterHashtblAlphabetically (fun _name (union : gqlUnion) ->
-      addSection (printUnion union));
+      addSection (printUnion schemaState union));
 
   schemaState.inputObjects
   |> iterHashtblAlphabetically (fun _name (input : gqlInputObjectType) ->
-      addSection (printInputObject input));
+      addSection (printInputObject schemaState input));
 
   schemaState.inputUnions
   |> iterHashtblAlphabetically (fun _name (input : gqlInputUnionType) ->
-      addSection (printInputUnion input));
+      addSection (printInputUnion schemaState input));
 
   schemaState.interfaces
   |> iterHashtblAlphabetically (fun _name (intf : gqlInterface) ->
-      addSection (printInterface intf));
+      addSection (printInterface schemaState intf));
 
   schemaState.types
   |> iterHashtblAlphabetically (fun _name (typ : gqlObjectType) ->
-      addSection (printObjectType typ));
+      addSection (printObjectType schemaState typ));
   String.trim (Buffer.contents code) ^ "\n"

--- a/src/ml/GenerateSchemaSDL.ml
+++ b/src/ml/GenerateSchemaSDL.ml
@@ -45,10 +45,32 @@ let printImplements interfaces =
       |> String.concat " & ")
   else ""
 
+let escapeBlockString value =
+  let length = String.length value in
+  let buffer = Buffer.create (length + 8) in
+  let rec append index =
+    if index >= length then ()
+    else if
+      index + 2 < length
+      && value.[index] = '"'
+      && value.[index + 1] = '"'
+      && value.[index + 2] = '"'
+    then (
+      Buffer.add_string buffer "\\\"\"\"";
+      append (index + 3))
+    else (
+      Buffer.add_char buffer value.[index];
+      append (index + 1))
+  in
+  append 0;
+  Buffer.contents buffer
+
 let printDescription desc indentation =
   match desc with
   | None -> ""
-  | Some desc -> Printf.sprintf "\n%s\"\"\"%s\"\"\"\n" (indent indentation) desc
+  | Some desc ->
+    Printf.sprintf "\n%s\"\"\"%s\"\"\"\n" (indent indentation)
+      (escapeBlockString desc)
 
 let printDeprecatedDirective deprecationReason =
   match deprecationReason with

--- a/src/ml/GenerateSchemaTypePrinters.ml
+++ b/src/ml/GenerateSchemaTypePrinters.ml
@@ -193,6 +193,84 @@ let rec printGraphQLType ?(nullable = false) (returnType : graphqlType) =
       nullablePostfix
   | InjectContext | InjectInfo -> "Obj.magic()"
 
+let floatLiteral value =
+  if
+    String.contains value '.' || String.contains value 'e'
+    || String.contains value 'E'
+  then value
+  else value ^ "."
+
+let rec printConstValue = function
+  | ConstNull -> "GraphQLLiteralValue.Null"
+  | ConstInt value | ConstFloat value ->
+    Printf.sprintf "GraphQLLiteralValue.Number(%s)" (floatLiteral value)
+  | ConstString value | ConstEnum value ->
+    Printf.sprintf "GraphQLLiteralValue.String(\"%s\")" (Json.escape value)
+  | ConstBoolean true -> "GraphQLLiteralValue.True"
+  | ConstBoolean false -> "GraphQLLiteralValue.False"
+  | ConstList values ->
+    Printf.sprintf "GraphQLLiteralValue.Array([%s])"
+      (values |> List.map printConstValue |> String.concat ", ")
+  | ConstObject fields ->
+    Printf.sprintf "GraphQLLiteralValue.Object(dict{%s})"
+      (fields
+      |> List.map (fun (name, value) ->
+          Printf.sprintf "\"%s\": %s" name (printConstValue value))
+      |> String.concat ", ")
+
+let printDirectiveArguments arguments =
+  Printf.sprintf "dict{%s}"
+    (arguments
+    |> List.map (fun (name, value) ->
+        Printf.sprintf "\"%s\": %s" name (printConstValue value))
+    |> String.concat ", ")
+
+let groupDirectiveApplications applications =
+  applications
+  |> List.fold_left
+       (fun groups (application : gqlDirectiveApplication) ->
+         let rec add = function
+           | [] -> [(application.name, [application.arguments])]
+           | (name, arguments) :: rest when name = application.name ->
+             (name, arguments @ [application.arguments]) :: rest
+           | group :: rest -> group :: add rest
+         in
+         add groups)
+       []
+
+let printDirectiveExtensions ?(oneOf = false) schemaState target =
+  let applications =
+    GenerateSchemaUtils.directivesForTarget schemaState target
+  in
+  if applications = [] && not oneOf then None
+  else
+    let fields = ref [] in
+    (if applications <> [] then
+       let directives =
+         applications |> groupDirectiveApplications
+         |> List.map (fun (name, argumentSets) ->
+             Printf.sprintf "\"%s\": [%s]" name
+               (argumentSets
+               |> List.map printDirectiveArguments
+               |> String.concat ", "))
+         |> String.concat ", "
+       in
+       let ordered =
+         applications
+         |> List.map (fun (application : gqlDirectiveApplication) ->
+             Printf.sprintf "{name: \"%s\", args: %s}" application.name
+               (printDirectiveArguments application.arguments))
+         |> String.concat ", "
+       in
+       fields :=
+         !fields
+         @ [
+             Printf.sprintf "directives: dict{%s}" directives;
+             Printf.sprintf "resgraph: {appliedDirectives: [%s]}" ordered;
+           ]);
+    if oneOf then fields := !fields @ ["oneOf: true"];
+    Some (Printf.sprintf "{%s}" (String.concat ", " !fields))
+
 let displayNameFromImplementedBy
     (interfaceImplementedBy : interfaceImplementedBy) =
   match interfaceImplementedBy with
@@ -306,7 +384,7 @@ let printInterfaceTypenameToString
   else Printf.sprintf "external toString: t => string = \"%%identity\""
 
 let printArg (arg : gqlArg) =
-  Printf.sprintf "{typ: %s}" (printGraphQLType arg.typ)
+  Printf.sprintf "({typ: %s}: arg)" (printGraphQLType arg.typ)
 
 let printArgs (args : gqlArg list) =
   let args =
@@ -316,14 +394,76 @@ let printArgs (args : gqlArg list) =
   in
   let writer = CodeWriter.create 256 in
   let lastArgIndex = List.length args - 1 in
-  CodeWriter.line writer "{";
+  CodeWriter.line writer "dict{";
   CodeWriter.indented writer (fun () ->
       args
       |> List.iteri (fun index (arg : gqlArg) ->
           CodeWriter.line writer
             (Printf.sprintf "\"%s\": %s%s" arg.name (printArg arg)
                (if index = lastArgIndex then "" else ","))));
-  CodeWriter.add writer "}->makeArgs";
+  CodeWriter.add writer "}->makeArgsDict";
+  CodeWriter.contents writer
+
+let printDirectiveArgument schemaState directiveName
+    (argument : gqlDirectiveArgument) =
+  let writer = CodeWriter.create 256 in
+  CodeWriter.line writer "({";
+  CodeWriter.indented writer (fun () ->
+      CodeWriter.line writer
+        (Printf.sprintf "typ: %s," (printGraphQLType argument.typ));
+      (match argument.defaultValue with
+      | None -> ()
+      | Some value ->
+        CodeWriter.line writer
+          (Printf.sprintf "defaultValue: %s," (printConstValue value)));
+      CodeWriter.line writer
+        (Printf.sprintf "description: %s,"
+           (descriptionAsString argument.description));
+      CodeWriter.line writer
+        (Printf.sprintf "deprecationReason: %s,"
+           (undefinedOrValueAsString argument.deprecationReason));
+      match
+        printDirectiveExtensions schemaState
+          (DirectiveDirectiveArgumentDefinition
+             {directiveName; argumentName = argument.name})
+      with
+      | None -> ()
+      | Some extensions ->
+        CodeWriter.line writer (Printf.sprintf "extensions: %s" extensions));
+  CodeWriter.add writer "}: arg)";
+  CodeWriter.contents writer
+
+let printDirectiveDefinition schemaState (definition : gqlDirectiveDefinition) =
+  let writer = CodeWriter.create 512 in
+  CodeWriter.line writer "{";
+  CodeWriter.indented writer (fun () ->
+      CodeWriter.line writer (Printf.sprintf "name: \"%s\"," definition.name);
+      CodeWriter.line writer
+        (Printf.sprintf "description: %s,"
+           (descriptionAsString definition.description));
+      CodeWriter.line writer
+        (Printf.sprintf "locations: [%s],"
+           (definition.locations
+           |> List.map (fun location ->
+               Printf.sprintf "\"%s\""
+                 (GenerateSchemaDirectiveUtils.locationToString location))
+           |> String.concat ", "));
+      if definition.arguments <> [] then (
+        CodeWriter.line writer "args: dict{";
+        CodeWriter.indented writer (fun () ->
+            definition.arguments
+            |> List.iteri (fun index (argument : gqlDirectiveArgument) ->
+                CodeWriter.add writer (Printf.sprintf "\"%s\": " argument.name);
+                CodeWriter.add writer
+                  (printDirectiveArgument schemaState definition.name argument);
+                CodeWriter.line writer
+                  (if index = List.length definition.arguments - 1 then ""
+                   else ",")));
+        CodeWriter.line writer "}->makeArgsDict,");
+      CodeWriter.line writer
+        (Printf.sprintf "isRepeatable: %s"
+           (if definition.repeatable then "true" else "false")));
+  CodeWriter.add writer "}";
   CodeWriter.contents writer
 
 let printField ?(context = CtxDefault) ~parentTypeName ~schemaState
@@ -344,6 +484,13 @@ let printField ?(context = CtxDefault) ~parentTypeName ~schemaState
         CodeWriter.add writer "args: ";
         CodeWriter.add writer (printArgs printableArgs);
         CodeWriter.line writer ",");
+      (match
+         printDirectiveExtensions schemaState
+           (DirectiveFieldDefinition {parentTypeName; fieldName = field.name})
+       with
+      | None -> ()
+      | Some extensions ->
+        CodeWriter.line writer (Printf.sprintf "extensions: %s," extensions));
       match context with
       | CtxDefault ->
         CodeWriter.line writer
@@ -359,7 +506,7 @@ let printField ?(context = CtxDefault) ~parentTypeName ~schemaState
   CodeWriter.add writer "}";
   CodeWriter.contents writer
 
-let printInputObjectField (field : gqlField) =
+let printInputObjectField ~schemaState ~parentTypeName (field : gqlField) =
   let writer = CodeWriter.create 256 in
   CodeWriter.line writer "{";
   CodeWriter.indented writer (fun () ->
@@ -370,8 +517,16 @@ let printInputObjectField (field : gqlField) =
         (Printf.sprintf "description: %s,"
            (field.description |> descriptionAsString));
       CodeWriter.line writer
-        (Printf.sprintf "deprecationReason: %s"
-           (field.deprecationReason |> undefinedOrValueAsString)));
+        (Printf.sprintf "deprecationReason: %s,"
+           (field.deprecationReason |> undefinedOrValueAsString));
+      match
+        printDirectiveExtensions schemaState
+          (DirectiveInputFieldDefinition
+             {inputObjectName = parentTypeName; fieldName = field.name})
+      with
+      | None -> ()
+      | Some extensions ->
+        CodeWriter.line writer (Printf.sprintf "extensions: %s" extensions));
   CodeWriter.add writer "}";
   CodeWriter.contents writer
 
@@ -399,7 +554,8 @@ let printFields ?context ~parentTypeName ~schemaState fields =
     (fun field -> printField ?context ~parentTypeName ~schemaState field)
     fields
 
-let printInputObjectFields fields = printFieldsWith printInputObjectField fields
+let printInputObjectFields ~schemaState ~parentTypeName fields =
+  printFieldsWith (printInputObjectField ~schemaState ~parentTypeName) fields
 
 let printObjectType ~(schemaState : schemaState) (typ : gqlObjectType) =
   let writer = CodeWriter.create 1024 in
@@ -416,6 +572,12 @@ let printObjectType ~(schemaState : schemaState) (typ : gqlObjectType) =
                Printf.sprintf "get_%s()"
                  (GenerateSchemaUtils.capitalizeFirstChar id))
            |> String.concat ", "));
+      (match
+         printDirectiveExtensions schemaState (DirectiveObject typ.displayName)
+       with
+      | None -> ()
+      | Some extensions ->
+        CodeWriter.line writer (Printf.sprintf "extensions: %s," extensions));
       CodeWriter.add writer "fields: () => ";
       CodeWriter.add writer
         (printFields
@@ -426,11 +588,19 @@ let printObjectType ~(schemaState : schemaState) (typ : gqlObjectType) =
   CodeWriter.add writer "}";
   CodeWriter.contents writer
 
-let printScalar (typ : gqlScalar) =
+let printScalar ~schemaState (typ : gqlScalar) =
+  let extensions =
+    printDirectiveExtensions schemaState (DirectiveScalar typ.displayName)
+  in
   match typ.encoderDecoderLoc with
   | None ->
-    Printf.sprintf "{name: \"%s\", description: %s}" typ.displayName
+    Printf.sprintf "{name: \"%s\", description: %s, specifiedByURL: %s%s}"
+      typ.displayName
       (descriptionAsString typ.description)
+      (undefinedOrValueAsString typ.specifiedByUrl)
+      (match extensions with
+      | None -> ""
+      | Some extensions -> ", extensions: " ^ extensions)
   | Some encoderDecoderLoc ->
     let writer = CodeWriter.create 256 in
     CodeWriter.line writer "{";
@@ -444,6 +614,14 @@ let printScalar (typ : gqlScalar) =
             CodeWriter.line writer
               (Printf.sprintf "description: %s,"
                  (descriptionAsString typ.description));
+            CodeWriter.line writer
+              (Printf.sprintf "specifiedByURL: %s,"
+                 (undefinedOrValueAsString typ.specifiedByUrl));
+            (match extensions with
+            | None -> ()
+            | Some extensions ->
+              CodeWriter.line writer
+                (Printf.sprintf "extensions: %s," extensions));
             CodeWriter.line writer
               (Printf.sprintf "parseValue: %s,"
                  (typeLocationModuleToAccesor encoderDecoderLoc ["parseValue"]));
@@ -470,6 +648,13 @@ let printInterfaceType ~(schemaState : schemaState) (typ : gqlInterface) =
                Printf.sprintf "get_%s()"
                  (GenerateSchemaUtils.capitalizeFirstChar id))
            |> String.concat ", "));
+      (match
+         printDirectiveExtensions schemaState
+           (DirectiveInterface typ.displayName)
+       with
+      | None -> ()
+      | Some extensions ->
+        CodeWriter.line writer (Printf.sprintf "extensions: %s," extensions));
       CodeWriter.add writer "fields: () => ";
       CodeWriter.add writer
         (printFields ~context:CtxInterface ~parentTypeName:typ.displayName
@@ -483,7 +668,8 @@ let printInterfaceType ~(schemaState : schemaState) (typ : gqlInterface) =
   CodeWriter.add writer "}";
   CodeWriter.contents writer
 
-let printInputObjectType ?(inputUnion = false) (typ : gqlInputObjectType) =
+let printInputObjectType ~schemaState ?(inputUnion = false)
+    (typ : gqlInputObjectType) =
   let writer = CodeWriter.create 512 in
   CodeWriter.line writer "{";
   CodeWriter.indented writer (fun () ->
@@ -492,15 +678,21 @@ let printInputObjectType ?(inputUnion = false) (typ : gqlInputObjectType) =
         (Printf.sprintf "description: %s,"
            (descriptionAsString typ.description));
       CodeWriter.add writer "fields: () => ";
-      CodeWriter.add writer (printInputObjectFields typ.fields);
-      if inputUnion then (
+      CodeWriter.add writer
+        (printInputObjectFields ~schemaState ~parentTypeName:typ.displayName
+           typ.fields);
+      match
+        printDirectiveExtensions ~oneOf:inputUnion schemaState
+          (DirectiveInputObject typ.displayName)
+      with
+      | None -> CodeWriter.newline writer
+      | Some extensions ->
         CodeWriter.line writer ",";
-        CodeWriter.line writer "extensions: {oneOf: true}")
-      else CodeWriter.newline writer);
+        CodeWriter.line writer (Printf.sprintf "extensions: %s" extensions));
   CodeWriter.add writer "}";
   CodeWriter.contents writer
 
-let printUnionType (union : gqlUnion) =
+let printUnionType ~schemaState (union : gqlUnion) =
   let writer = CodeWriter.create 512 in
   CodeWriter.line writer "{";
   CodeWriter.indented writer (fun () ->
@@ -508,6 +700,12 @@ let printUnionType (union : gqlUnion) =
       CodeWriter.line writer
         (Printf.sprintf "description: %s,"
            (descriptionAsString union.description));
+      (match
+         printDirectiveExtensions schemaState (DirectiveUnion union.displayName)
+       with
+      | None -> ()
+      | Some extensions ->
+        CodeWriter.line writer (Printf.sprintf "extensions: %s," extensions));
       CodeWriter.line writer
         (Printf.sprintf "types: () => [%s],"
            (union.types
@@ -781,7 +979,8 @@ let printSchemaJsFile schemaState processSchema ~interfaceModulePrefix =
   |> iterHashtblAlphabetically (fun _name (scalar : gqlScalar) ->
       addWithNewLine
         (Printf.sprintf "let scalar_%s = GraphQLScalar.make(%s)"
-           scalar.displayName (printScalar scalar)));
+           scalar.displayName
+           (printScalar ~schemaState scalar)));
   addWithNewLine "";
 
   (* Print all enums. These won't have any other dependencies. *)
@@ -794,17 +993,32 @@ let printSchemaJsFile schemaState processSchema ~interfaceModulePrefix =
           CodeWriter.line code
             (Printf.sprintf "description: %s,"
                (descriptionAsString enum.description));
+          (match
+             printDirectiveExtensions schemaState
+               (DirectiveEnum enum.displayName)
+           with
+          | None -> ()
+          | Some extensions ->
+            CodeWriter.line code (Printf.sprintf "extensions: %s," extensions));
           CodeWriter.line code "values: {";
           CodeWriter.indented code (fun () ->
               enum.values
               |> List.iter (fun (value : gqlEnumValue) ->
+                  let extensions =
+                    printDirectiveExtensions schemaState
+                      (DirectiveEnumValue
+                         {enumName = enum.displayName; valueName = value.value})
+                  in
                   CodeWriter.line code
                     (Printf.sprintf
                        "\"%s\": {GraphQLEnumType.value: \"%s\", description: \
-                        %s, deprecationReason: %s},"
+                        %s, deprecationReason: %s%s},"
                        value.value value.value
                        (descriptionAsString value.description)
-                       (undefinedOrValueAsString value.deprecationReason))));
+                       (undefinedOrValueAsString value.deprecationReason)
+                       (match extensions with
+                       | None -> ""
+                       | Some extensions -> ", extensions: " ^ extensions))));
           CodeWriter.line code "}->makeEnumValues,");
       CodeWriter.line code "})";
       CodeWriter.blankLine code);
@@ -950,7 +1164,7 @@ let printSchemaJsFile schemaState processSchema ~interfaceModulePrefix =
       addWithNewLine
         (Printf.sprintf "input_%s.contents = GraphQLInputObjectType.make(%s)"
            typ.displayName
-           (typ |> printInputObjectType)));
+           (typ |> printInputObjectType ~schemaState)));
 
   schemaState.inputUnions
   |> iterHashtblAlphabetically (fun _name (typ : gqlInputUnionType) ->
@@ -958,15 +1172,32 @@ let printSchemaJsFile schemaState processSchema ~interfaceModulePrefix =
         (Printf.sprintf
            "inputUnion_%s.contents = GraphQLInputObjectType.make(%s)"
            typ.displayName
-           (typ |> inputUnionToInputObj |> printInputObjectType ~inputUnion:true)));
+           (typ |> inputUnionToInputObj
+           |> printInputObjectType ~schemaState ~inputUnion:true)));
 
   schemaState.unions
   |> iterHashtblAlphabetically (fun _name (union : gqlUnion) ->
       addWithNewLine
         (Printf.sprintf "union_%s.contents = GraphQLUnionType.make(%s)"
-           union.displayName (union |> printUnionType)));
+           union.displayName
+           (union |> printUnionType ~schemaState)));
+
+  if Hashtbl.length schemaState.directiveDefinitions > 0 then
+    CodeWriter.blankLine code;
+  schemaState.directiveDefinitions
+  |> iterHashtblAlphabetically
+       (fun _name (definition : gqlDirectiveDefinition) ->
+         addWithNewLine
+           (Printf.sprintf "let directive_%s = GraphQLDirective.make(%s)"
+              definition.name
+              (printDirectiveDefinition schemaState definition)));
 
   (* Print the schema gluing it all together. *)
+  let customDirectives =
+    hashtblToListAlphabetically schemaState.directiveDefinitions
+    |> List.map (fun (_name, (definition : gqlDirectiveDefinition)) ->
+        "directive_" ^ definition.name)
+  in
   let schemaTypes =
     (hashtblToListAlphabetically schemaState.types
     |> List.map (fun (_name, (typ : gqlObjectType)) ->
@@ -991,16 +1222,21 @@ let printSchemaJsFile schemaState processSchema ~interfaceModulePrefix =
   in
   let lastSchemaTypeIndex = List.length schemaTypes - 1 in
   CodeWriter.blankLine code;
-  CodeWriter.line code "let schema = GraphQLSchemaType.make({";
+  CodeWriter.line code "let schema = GraphQLSchemaType.makeConfig({";
   CodeWriter.indented code (fun () ->
-      CodeWriter.line code "\"query\": get_Query(),";
+      CodeWriter.line code "query: get_Query(),";
       (match schemaState.mutation with
       | None -> ()
-      | Some _ -> CodeWriter.line code "\"mutation\": get_Mutation(),");
+      | Some _ -> CodeWriter.line code "mutation: get_Mutation(),");
       (match schemaState.subscription with
       | None -> ()
-      | Some _ -> CodeWriter.line code "\"subscription\": get_Subscription(),");
-      CodeWriter.line code "\"types\": [";
+      | Some _ -> CodeWriter.line code "subscription: get_Subscription(),");
+      if customDirectives <> [] then
+        CodeWriter.line code
+          (Printf.sprintf
+             "directives: [...GraphQLDirective.specifiedDirectives, %s],"
+             (String.concat ", " customDirectives));
+      CodeWriter.line code "types: [";
       CodeWriter.indented code (fun () ->
           schemaTypes
           |> List.iteri (fun index schemaType ->

--- a/src/ml/GenerateSchemaTypePrinters.ml
+++ b/src/ml/GenerateSchemaTypePrinters.ml
@@ -218,11 +218,28 @@ let rec printConstValue = function
           Printf.sprintf "\"%s\": %s" name (printConstValue value))
       |> String.concat ", ")
 
-let printDirectiveArguments arguments =
+let printCoercedValue typ value =
+  Printf.sprintf "GraphQLInput.coerceValue(%s, %s)" (printConstValue value)
+    (printGraphQLType typ)
+
+let printDirectiveValue schemaState directiveName argumentName value =
+  match
+    Option.bind
+      (Hashtbl.find_opt schemaState.directiveDefinitions directiveName)
+      (fun (definition : gqlDirectiveDefinition) ->
+        definition.arguments
+        |> List.find_opt (fun (argument : gqlDirectiveArgument) ->
+            argument.name = argumentName))
+  with
+  | Some argument -> printCoercedValue argument.typ value
+  | None -> printConstValue value
+
+let printDirectiveArguments schemaState directiveName arguments =
   Printf.sprintf "dict{%s}"
     (arguments
     |> List.map (fun (name, value) ->
-        Printf.sprintf "\"%s\": %s" name (printConstValue value))
+        Printf.sprintf "\"%s\": %s" name
+          (printDirectiveValue schemaState directiveName name value))
     |> String.concat ", ")
 
 let groupDirectiveApplications applications =
@@ -251,7 +268,7 @@ let printDirectiveExtensions ?(oneOf = false) schemaState target =
          |> List.map (fun (name, argumentSets) ->
              Printf.sprintf "\"%s\": [%s]" name
                (argumentSets
-               |> List.map printDirectiveArguments
+               |> List.map (printDirectiveArguments schemaState name)
                |> String.concat ", "))
          |> String.concat ", "
        in
@@ -259,7 +276,8 @@ let printDirectiveExtensions ?(oneOf = false) schemaState target =
          applications
          |> List.map (fun (application : gqlDirectiveApplication) ->
              Printf.sprintf "{name: \"%s\", args: %s}" application.name
-               (printDirectiveArguments application.arguments))
+               (printDirectiveArguments schemaState application.name
+                  application.arguments))
          |> String.concat ", "
        in
        fields :=
@@ -415,7 +433,8 @@ let printDirectiveArgument schemaState directiveName
       | None -> ()
       | Some value ->
         CodeWriter.line writer
-          (Printf.sprintf "defaultValue: %s," (printConstValue value)));
+          (Printf.sprintf "defaultValue: %s,"
+             (printCoercedValue argument.typ value)));
       CodeWriter.line writer
         (Printf.sprintf "description: %s,"
            (descriptionAsString argument.description));

--- a/src/ml/GenerateSchemaTypePrinters.ml
+++ b/src/ml/GenerateSchemaTypePrinters.ml
@@ -172,7 +172,7 @@ let rec printGraphQLType ?(nullable = false) (returnType : graphqlType) =
     Printf.sprintf "get_%s()->GraphQLObjectType.toGraphQLType%s" displayName
       nullablePostfix
   | GraphQLScalar {displayName} ->
-    Printf.sprintf "scalar_%s->GraphQLScalar.toGraphQLType%s" displayName
+    Printf.sprintf "getScalar_%s()->GraphQLScalar.toGraphQLType%s" displayName
       nullablePostfix
   | GraphQLInterface {displayName} ->
     Printf.sprintf "get_%s()->GraphQLInterfaceType.toGraphQLType%s" displayName
@@ -186,7 +186,7 @@ let rec printGraphQLType ?(nullable = false) (returnType : graphqlType) =
     Printf.sprintf "get_%s()->GraphQLInputObjectType.toGraphQLType%s"
       displayName nullablePostfix
   | GraphQLEnum {displayName} ->
-    Printf.sprintf "enum_%s->GraphQLEnumType.toGraphQLType%s" displayName
+    Printf.sprintf "getEnum_%s()->GraphQLEnumType.toGraphQLType%s" displayName
       nullablePostfix
   | GraphQLUnion {displayName} ->
     Printf.sprintf "get_%s()->GraphQLUnionType.toGraphQLType%s" displayName
@@ -235,10 +235,10 @@ let printDirectiveValue schemaState directiveName argumentName value =
   | None -> printConstValue value
 
 let printDirectiveArguments schemaState directiveName arguments =
-  Printf.sprintf "dict{%s}"
+  Printf.sprintf "makeLazyDirectiveArguments(dict{%s})"
     (arguments
     |> List.map (fun (name, value) ->
-        Printf.sprintf "\"%s\": %s" name
+        Printf.sprintf "\"%s\": () => %s" name
           (printDirectiveValue schemaState directiveName name value))
     |> String.concat ", ")
 
@@ -993,20 +993,44 @@ let printSchemaJsFile schemaState processSchema ~interfaceModulePrefix =
 }`)|};
   addWithNewLine "";
 
+  (* Scalar and enum directive values may depend on types constructed later.
+     Declare holders first so lazy directive coercion can safely capture every
+     input type regardless of construction order. *)
+  schemaState.scalars
+  |> iterHashtblAlphabetically (fun _name (scalar : gqlScalar) ->
+      addWithNewLine
+        (Printf.sprintf
+           "let scalar_%s: ref<GraphQLScalar.t> = Obj.magic({\"contents\": null})"
+           scalar.displayName);
+      addWithNewLine
+        (Printf.sprintf "let getScalar_%s = () => scalar_%s.contents"
+           scalar.displayName scalar.displayName));
+  schemaState.enums
+  |> iterHashtblAlphabetically (fun _name (enum : gqlEnum) ->
+      addWithNewLine
+        (Printf.sprintf
+           "let enum_%s: ref<GraphQLEnumType.t> = Obj.magic({\"contents\": null})"
+           enum.displayName);
+      addWithNewLine
+        (Printf.sprintf "let getEnum_%s = () => enum_%s.contents"
+           enum.displayName enum.displayName));
+  addWithNewLine "";
+
+  let printScalarsAndEnums () =
   (* Print all custom scalars. *)
   schemaState.scalars
   |> iterHashtblAlphabetically (fun _name (scalar : gqlScalar) ->
       addWithNewLine
-        (Printf.sprintf "let scalar_%s = GraphQLScalar.make(%s)"
+        (Printf.sprintf "scalar_%s.contents = GraphQLScalar.make(%s)"
            scalar.displayName
            (printScalar ~schemaState scalar)));
-  addWithNewLine "";
+  if Hashtbl.length schemaState.scalars > 0 then addWithNewLine "";
 
   (* Print all enums. These won't have any other dependencies. *)
   schemaState.enums
   |> iterHashtblAlphabetically (fun _name (enum : gqlEnum) ->
       CodeWriter.line code
-        (Printf.sprintf "let enum_%s = GraphQLEnumType.make({" enum.displayName);
+        (Printf.sprintf "enum_%s.contents = GraphQLEnumType.make({" enum.displayName);
       CodeWriter.indented code (fun () ->
           CodeWriter.line code (Printf.sprintf "name: \"%s\"," enum.displayName);
           CodeWriter.line code
@@ -1040,7 +1064,8 @@ let printSchemaJsFile schemaState processSchema ~interfaceModulePrefix =
                        | Some extensions -> ", extensions: " ^ extensions))));
           CodeWriter.line code "}->makeEnumValues,");
       CodeWriter.line code "})";
-      CodeWriter.blankLine code);
+      CodeWriter.blankLine code)
+  in
 
   (* Print the interface type holders and getters *)
   schemaState.interfaces
@@ -1118,6 +1143,7 @@ let printSchemaJsFile schemaState processSchema ~interfaceModulePrefix =
            union.displayName));
 
   addWithNewLine "";
+  printScalarsAndEnums ();
 
   (* Print support functions for union type resolution *)
   schemaState.unions
@@ -1237,7 +1263,7 @@ let printSchemaJsFile schemaState processSchema ~interfaceModulePrefix =
       )
     @ (hashtblToListAlphabetically schemaState.enums
       |> List.map (fun (_name, (typ : gqlEnum)) ->
-          "enum_" ^ typ.displayName ^ "->GraphQLEnumType.toGraphQLType"))
+          "getEnum_" ^ typ.displayName ^ "()->GraphQLEnumType.toGraphQLType"))
   in
   let lastSchemaTypeIndex = List.length schemaTypes - 1 in
   CodeWriter.blankLine code;

--- a/src/ml/GenerateSchemaTypes.ml
+++ b/src/ml/GenerateSchemaTypes.ml
@@ -96,11 +96,91 @@ type typeLocation =
 
 type diagnostic = {loc: Location.t; fileUri: Uri.t; message: string}
 
+type gqlConstValue =
+  | ConstNull
+  | ConstInt of string
+  | ConstFloat of string
+  | ConstString of string
+  | ConstBoolean of bool
+  | ConstEnum of string
+  | ConstList of gqlConstValue list
+  | ConstObject of (string * gqlConstValue) list
+
+type gqlDirectiveLocation =
+  | LocationQuery
+  | LocationMutation
+  | LocationSubscription
+  | LocationField
+  | LocationFragmentDefinition
+  | LocationFragmentSpread
+  | LocationInlineFragment
+  | LocationVariableDefinition
+  | LocationSchema
+  | LocationScalar
+  | LocationObject
+  | LocationFieldDefinition
+  | LocationArgumentDefinition
+  | LocationInterface
+  | LocationUnion
+  | LocationEnum
+  | LocationEnumValue
+  | LocationInputObject
+  | LocationInputFieldDefinition
+
+type gqlDirectiveTarget =
+  | DirectiveSchema
+  | DirectiveScalar of string
+  | DirectiveObject of string
+  | DirectiveFieldDefinition of {parentTypeName: string; fieldName: string}
+  | DirectiveArgumentDefinition of {
+      parentTypeName: string;
+      fieldName: string;
+      argumentName: string;
+    }
+  | DirectiveDirectiveArgumentDefinition of {
+      directiveName: string;
+      argumentName: string;
+    }
+  | DirectiveInterface of string
+  | DirectiveUnion of string
+  | DirectiveEnum of string
+  | DirectiveEnumValue of {enumName: string; valueName: string}
+  | DirectiveInputObject of string
+  | DirectiveInputFieldDefinition of {
+      inputObjectName: string;
+      fieldName: string;
+    }
+
+type gqlDirectiveApplication = {
+  name: string;
+  arguments: (string * gqlConstValue) list;
+  loc: Location.t;
+  fileUri: Uri.t;
+}
+
 type gqlArg = {
   name: string;
   isOptionLabelled: bool;
       (* If the argument in ReScript is an optional label. *)
   typ: graphqlType; (* TODO: Default value. *)
+}
+
+type gqlDirectiveArgument = {
+  name: string;
+  typ: graphqlType;
+  description: string option;
+  defaultValue: gqlConstValue option;
+  deprecationReason: string option;
+  loc: Location.t;
+}
+
+type gqlDirectiveDefinition = {
+  name: string;
+  description: string option;
+  arguments: gqlDirectiveArgument list;
+  locations: gqlDirectiveLocation list;
+  repeatable: bool;
+  typeLocation: typeLocationLoc;
 }
 
 type gqlInterfaceIdentifier = {id: string; displayName: string}
@@ -230,6 +310,9 @@ type schemaState = {
   unions: (string, gqlUnion) Hashtbl.t;
   interfaces: (string, gqlInterface) Hashtbl.t;
   scalars: (string, gqlScalar) Hashtbl.t;
+  directiveDefinitions: (string, gqlDirectiveDefinition) Hashtbl.t;
+  appliedDirectives:
+    (gqlDirectiveTarget, gqlDirectiveApplication list) Hashtbl.t;
   processedFiles: (string, bool) Hashtbl.t;
   authorizationConfig: authorizationConfig;
   authorizationDeclarations: (string, declaredAuthorization) Hashtbl.t;
@@ -263,3 +346,4 @@ type gqlAttributes =
   | Enum
   | Union
   | Scalar
+  | Directive

--- a/src/ml/GenerateSchemaUtils.ml
+++ b/src/ml/GenerateSchemaUtils.ml
@@ -856,7 +856,34 @@ let undefinedOrValueAsString ?(escape = false) v =
   | None -> "?(None)"
   | Some v -> Printf.sprintf "\"%s\"" (if escape then Json.escape v else v)
 
-let descriptionAsString v = undefinedOrValueAsString ~escape:true v
+let escapeDescriptionForRescript value =
+  let escaped = Json.escape value in
+  let length = String.length escaped in
+  let buffer = Buffer.create (length + 16) in
+  let rec append index =
+    if index >= length then ()
+    else if
+      index + 5 < length
+      && escaped.[index] = '\\'
+      && escaped.[index + 1] = '"'
+      && escaped.[index + 2] = '\\'
+      && escaped.[index + 3] = '"'
+      && escaped.[index + 4] = '\\'
+      && escaped.[index + 5] = '"'
+    then (
+      Buffer.add_string buffer "\\u0022\\u0022\\u0022";
+      append (index + 6))
+    else (
+      Buffer.add_char buffer escaped.[index];
+      append (index + 1))
+  in
+  append 0;
+  Buffer.contents buffer
+
+let descriptionAsString = function
+  | None -> "?(None)"
+  | Some description ->
+    Printf.sprintf "\"%s\"" (escapeDescriptionForRescript description)
 
 let trimString str =
   let isSpace = function

--- a/src/ml/GenerateSchemaUtils.ml
+++ b/src/ml/GenerateSchemaUtils.ml
@@ -189,10 +189,18 @@ type directiveConfig = {locations: gqlDirectiveLocation list; repeatable: bool}
 
 let directiveConfigFromAttributes ~schemaState ~(env : SharedTypes.QueryEnv.t)
     attributes =
-  attributes
+  let directiveAttributes =
+    attributes
+    |> List.filter (fun ((name, _) : Parsetree.attribute) ->
+           name.txt = "gql.directive")
+  in
+  (match directiveAttributes with
+  | _ :: (name, _) :: _ ->
+    addDirectiveDiagnostic ~schemaState ~env ~loc:name.loc
+      "Only one `@gql.directive` annotation is allowed."
+  | _ -> ());
+  directiveAttributes
   |> List.find_map (fun ((name, payload) : Parsetree.attribute) ->
-      if name.txt <> "gql.directive" then None
-      else
         let invalid message =
           addDirectiveDiagnostic ~schemaState ~env ~loc:name.loc message;
           Some None

--- a/src/ml/GenerateSchemaUtils.ml
+++ b/src/ml/GenerateSchemaUtils.ml
@@ -41,6 +41,9 @@ let validAttributes =
     ("gql.inputObject", "");
     ("gql.inputUnion", "");
     ("gql.scalar", "");
+    ("gql.directive", "Defines a typed GraphQL directive.");
+    ("gql.annotate", "Applies a GraphQL directive to a schema element.");
+    ("gql.default", "Defines a GraphQL constant default value.");
     ("gql.authorize", "Attaches a typed authorization function.");
     ("gql.public", "Marks a field public with a required reason.");
   ]
@@ -93,7 +96,12 @@ let extractGqlAttribute ~(schemaState : GenerateSchemaTypes.schemaState)
       | ["gql"; "union"] -> Some Union
       | ["gql"; "inputObject"] -> Some InputObject
       | ["gql"; "inputUnion"] -> Some InputUnion
-      | ["gql"; "authorize"] | ["gql"; "public"] -> None
+      | ["gql"; "directive"] -> Some Directive
+      | ["gql"; "annotate"]
+      | ["gql"; "default"]
+      | ["gql"; "authorize"]
+      | ["gql"; "public"] ->
+        None
       | "gql" :: _ ->
         schemaState
         |> addDiagnostic
@@ -111,6 +119,314 @@ let extractGqlAttribute ~(schemaState : GenerateSchemaTypes.schemaState)
                };
         None
       | _ -> None)
+
+let addDirectiveDiagnostic ~(schemaState : schemaState)
+    ~(env : SharedTypes.QueryEnv.t) ~loc message =
+  schemaState
+  |> addDiagnostic ~diagnostic:{loc; fileUri = env.file.uri; message}
+
+let payloadExpressions (payload : Parsetree.payload) =
+  match payload with
+  | PStr [{pstr_desc = Pstr_eval (expression, _)}] -> (
+    match expression.pexp_desc with
+    | Pexp_tuple expressions -> expressions
+    | _ -> [expression])
+  | _ -> []
+
+let rec constValueFromExpression (expression : Parsetree.expression) =
+  let open Parsetree in
+  match expression.pexp_desc with
+  | Pexp_constant (Pconst_integer (value, _)) -> Ok (ConstInt value)
+  | Pexp_constant (Pconst_float (value, _)) -> Ok (ConstFloat value)
+  | Pexp_constant (Pconst_string (value, _)) -> Ok (ConstString value)
+  | Pexp_construct ({txt = Lident "true"}, None)
+  | Pexp_ident {txt = Lident "true"} ->
+    Ok (ConstBoolean true)
+  | Pexp_construct ({txt = Lident "false"}, None)
+  | Pexp_ident {txt = Lident "false"} ->
+    Ok (ConstBoolean false)
+  | Pexp_construct ({txt = Lident ("None" | "null")}, None)
+  | Pexp_ident {txt = Lident "null"} ->
+    Ok ConstNull
+  | Pexp_variant (name, None) -> Ok (ConstEnum name)
+  | Pexp_construct ({txt = constructor}, None) | Pexp_ident {txt = constructor}
+    ->
+    Ok (ConstEnum (Longident.last constructor))
+  | Pexp_array values ->
+    values
+    |> List.fold_left
+         (fun result value ->
+           match (result, constValueFromExpression value) with
+           | Ok values, Ok value -> Ok (value :: values)
+           | Error message, _ | _, Error message -> Error message)
+         (Ok [])
+    |> Result.map (fun values -> ConstList (List.rev values))
+  | Pexp_record (fields, None) ->
+    fields
+    |> List.fold_left
+         (fun result (field : Parsetree.expression Parsetree.record_element) ->
+           match (result, constValueFromExpression field.x) with
+           | Ok fields, Ok value ->
+             Ok ((Longident.last field.lid.txt, value) :: fields)
+           | Error message, _ | _, Error message -> Error message)
+         (Ok [])
+    |> Result.map (fun fields -> ConstObject (List.rev fields))
+  | Pexp_apply
+      {
+        funct = {pexp_desc = Pexp_ident {txt = Lident ("~-" | "~-." | "-")}};
+        args = [(_, value)];
+      } -> (
+    match constValueFromExpression value with
+    | Ok (ConstInt value) -> Ok (ConstInt ("-" ^ value))
+    | Ok (ConstFloat value) -> Ok (ConstFloat ("-" ^ value))
+    | _ -> Error "Only numeric GraphQL constant values can be negated.")
+  | _ ->
+    Error
+      "Expected a GraphQL constant: null, a boolean, number, string, enum, \
+       array, or record."
+
+type directiveConfig = {locations: gqlDirectiveLocation list; repeatable: bool}
+
+let directiveConfigFromAttributes ~schemaState ~(env : SharedTypes.QueryEnv.t)
+    attributes =
+  attributes
+  |> List.find_map (fun ((name, payload) : Parsetree.attribute) ->
+      if name.txt <> "gql.directive" then None
+      else
+        let invalid message =
+          addDirectiveDiagnostic ~schemaState ~env ~loc:name.loc message;
+          Some None
+        in
+        match payloadExpressions payload with
+        | [{pexp_desc = Pexp_record (fields, None)}] -> (
+          let fields =
+            fields
+            |> List.map
+                 (fun (field : Parsetree.expression Parsetree.record_element) ->
+                   (Longident.last field.lid.txt, field.x))
+          in
+          let unknownFields =
+            fields
+            |> List.filter_map (fun (fieldName, _) ->
+                if fieldName = "locations" || fieldName = "repeatable" then None
+                else Some fieldName)
+          in
+          if unknownFields <> [] then
+            invalid
+              (Printf.sprintf
+                 "Unknown `@gql.directive` configuration field%s: %s."
+                 (if List.length unknownFields = 1 then "" else "s")
+                 (String.concat ", " unknownFields))
+          else
+            let repeatable =
+              match List.assoc_opt "repeatable" fields with
+              | None -> Ok false
+              | Some
+                  {
+                    pexp_desc =
+                      ( Pexp_construct ({txt = Lident "true"}, None)
+                      | Pexp_ident {txt = Lident "true"} );
+                  } ->
+                Ok true
+              | Some
+                  {
+                    pexp_desc =
+                      ( Pexp_construct ({txt = Lident "false"}, None)
+                      | Pexp_ident {txt = Lident "false"} );
+                  } ->
+                Ok false
+              | Some _ -> Error "`repeatable` must be a boolean literal."
+            in
+            let locations =
+              match List.assoc_opt "locations" fields with
+              | Some {pexp_desc = Pexp_array values} ->
+                values
+                |> List.fold_left
+                     (fun result (value : Parsetree.expression) ->
+                       match (result, value.pexp_desc) with
+                       | ( Ok locations,
+                           Pexp_constant (Pconst_string (location, _)) ) -> (
+                         match
+                           GenerateSchemaDirectiveUtils.locationOfString
+                             location
+                         with
+                         | Some location -> Ok (location :: locations)
+                         | None ->
+                           Error
+                             (Printf.sprintf
+                                "`%s` is not a GraphQL directive location."
+                                location))
+                       | Error message, _ -> Error message
+                       | _ ->
+                         Error "`locations` must contain only string literals.")
+                     (Ok [])
+                |> Result.map List.rev
+              | Some _ -> Error "`locations` must be an array of strings."
+              | None -> Error "`@gql.directive` requires `locations`."
+            in
+            match (locations, repeatable) with
+            | Ok [], _ -> invalid "`@gql.directive` requires a location."
+            | Ok locations, Ok repeatable -> Some (Some {locations; repeatable})
+            | Error message, _ | _, Error message -> invalid message)
+        | _ ->
+          invalid
+            "`@gql.directive` requires a record payload, for example \
+             `@gql.directive({locations: [\"FIELD_DEFINITION\"]})`.")
+
+let defaultValueFromAttributes ~schemaState ~(env : SharedTypes.QueryEnv.t)
+    attributes =
+  let defaults =
+    attributes
+    |> List.filter (fun ((name, _) : Parsetree.attribute) ->
+        name.txt = "gql.default")
+  in
+  match defaults with
+  | [] -> None
+  | (name, payload) :: rest -> (
+    if rest <> [] then
+      addDirectiveDiagnostic ~schemaState ~env ~loc:name.loc
+        "Only one `@gql.default` annotation is allowed.";
+    match payloadExpressions payload with
+    | [expression] -> (
+      match constValueFromExpression expression with
+      | Ok value -> Some value
+      | Error message ->
+        addDirectiveDiagnostic ~schemaState ~env ~loc:name.loc message;
+        None)
+    | _ ->
+      addDirectiveDiagnostic ~schemaState ~env ~loc:name.loc
+        "`@gql.default` requires exactly one GraphQL constant value.";
+      None)
+
+let specifiedByUrlFromAttributes ~schemaState ~(env : SharedTypes.QueryEnv.t)
+    attributes =
+  attributes
+  |> List.find_map (fun ((name, payload) : Parsetree.attribute) ->
+      if name.txt <> "specifiedBy" then None
+      else
+        match payloadExpressions payload with
+        | [{pexp_desc = Pexp_constant (Pconst_string (url, _))}] -> Some url
+        | _ ->
+          addDirectiveDiagnostic ~schemaState ~env ~loc:name.loc
+            "`@specifiedBy` requires a string URL.";
+          None)
+
+let directiveApplicationsFromAttributes ~schemaState
+    ~(env : SharedTypes.QueryEnv.t) attributes =
+  let parseArgumentFields fields =
+    fields
+    |> List.fold_left
+         (fun result (field : Parsetree.expression Parsetree.record_element) ->
+           match (result, constValueFromExpression field.x) with
+           | Ok arguments, Ok value ->
+             Ok ((Longident.last field.lid.txt, value) :: arguments)
+           | Error message, _ | _, Error message -> Error message)
+         (Ok [])
+    |> Result.map List.rev
+  in
+  let parseArguments = function
+    | None -> Ok []
+    | Some {Parsetree.pexp_desc = Pexp_record (fields, None)} ->
+      parseArgumentFields fields
+    | Some _ -> Error "`args` must be a record of GraphQL constant values."
+  in
+  attributes
+  |> List.filter_map (fun ((attributeName, payload) : Parsetree.attribute) ->
+      if attributeName.txt <> "gql.annotate" then None
+      else
+        let invalid message =
+          addDirectiveDiagnostic ~schemaState ~env ~loc:attributeName.loc
+            message;
+          None
+        in
+        match payloadExpressions payload with
+        | [{pexp_desc = Pexp_constant (Pconst_string (name, _))}] ->
+          Some
+            {
+              name;
+              arguments = [];
+              loc = attributeName.loc;
+              fileUri = env.file.uri;
+            }
+        | [{pexp_desc = Pexp_record (fields, None)}] -> (
+          let fields =
+            fields
+            |> List.map
+                 (fun (field : Parsetree.expression Parsetree.record_element) ->
+                   (Longident.last field.lid.txt, field.x))
+          in
+          let unknownFields =
+            fields
+            |> List.filter_map (fun (name, _) ->
+                if name = "name" || name = "args" then None else Some name)
+          in
+          if unknownFields <> [] then
+            invalid
+              (Printf.sprintf
+                 "Unknown `@gql.annotate` configuration field%s: %s."
+                 (if List.length unknownFields = 1 then "" else "s")
+                 (String.concat ", " unknownFields))
+          else
+            match
+              (List.assoc_opt "name" fields, List.assoc_opt "args" fields)
+            with
+            | ( Some {pexp_desc = Pexp_constant (Pconst_string (name, _))},
+                arguments ) -> (
+              match parseArguments arguments with
+              | Ok arguments ->
+                Some
+                  {
+                    name;
+                    arguments;
+                    loc = attributeName.loc;
+                    fileUri = env.file.uri;
+                  }
+              | Error message -> invalid message)
+            | _ -> invalid "`@gql.annotate` requires a string `name` field.")
+        | [
+         {pexp_desc = Pexp_constant (Pconst_string (name, _))};
+         {pexp_desc = Pexp_record (fields, None)};
+        ] -> (
+          parseArgumentFields fields |> function
+          | Ok arguments ->
+            Some
+              {
+                name;
+                arguments = List.rev arguments;
+                loc = attributeName.loc;
+                fileUri = env.file.uri;
+              }
+          | Error message -> invalid message)
+        | _ ->
+          invalid
+            "`@gql.annotate` expects `{name: \"directive\"}` with an optional \
+             `args` record of GraphQL constant values.")
+
+let registerDirectiveApplications ~target ~attributes ~schemaState ~env =
+  let applications =
+    directiveApplicationsFromAttributes ~schemaState ~env attributes
+  in
+  match applications with
+  | [] -> ()
+  | applications ->
+    let existing =
+      Hashtbl.find_opt schemaState.appliedDirectives target
+      |> Option.value ~default:[]
+    in
+    let applications =
+      applications
+      |> List.filter (fun (application : gqlDirectiveApplication) ->
+          existing
+          |> List.exists (fun (existingApplication : gqlDirectiveApplication) ->
+              existingApplication.loc = application.loc)
+          |> not)
+    in
+    Hashtbl.replace schemaState.appliedDirectives target
+      (existing @ applications)
+
+let directivesForTarget (schemaState : schemaState) target =
+  Hashtbl.find_opt schemaState.appliedDirectives target
+  |> Option.value ~default:[]
 
 let extractGqlImplementsAttributes
     ~(schemaState : GenerateSchemaTypes.schemaState)
@@ -465,8 +781,8 @@ let addInputUnion id ~(makeInputUnion : unit -> gqlInputUnionType) ~debug
     if debug then Printf.printf "Adding input union %s\n" id;
     Hashtbl.replace schemaState.inputUnions id (makeInputUnion ()))
 
-let addScalar ~debug ~schemaState ?description ~typeLocation ?encoderDecoderLoc
-    id =
+let addScalar ~debug ~schemaState ?description ?specifiedByUrl ~typeLocation
+    ?encoderDecoderLoc id =
   if Hashtbl.mem schemaState.scalars id then ()
   else (
     if debug then Printf.printf "Adding scalar %s\n" id;
@@ -476,7 +792,7 @@ let addScalar ~debug ~schemaState ?description ~typeLocation ?encoderDecoderLoc
         displayName = capitalizeFirstChar id;
         description;
         typeLocation;
-        specifiedByUrl = None;
+        specifiedByUrl;
         encoderDecoderLoc;
       })
 
@@ -1311,7 +1627,7 @@ type persistedLegacySchemaState = {
 }
 
 let stateFileMagic = "RESGRAPH_STATE\000"
-let stateFileVersion = 1
+let stateFileVersion = 2
 
 let validStateName schemaName =
   Str.string_match (Str.regexp "^[A-Za-z0-9_-]+$") schemaName 0

--- a/src/ml/GenerateSchemaUtils.ml
+++ b/src/ml/GenerateSchemaUtils.ml
@@ -392,7 +392,7 @@ let directiveApplicationsFromAttributes ~schemaState
             Some
               {
                 name;
-                arguments = List.rev arguments;
+                arguments;
                 loc = attributeName.loc;
                 fileUri = env.file.uri;
               }

--- a/src/ml/GenerateSchemaValidation.ml
+++ b/src/ml/GenerateSchemaValidation.ml
@@ -18,12 +18,43 @@ let emptyLoc =
 let mkTypeLocation ~typeName ~fileName ~fileUri ~loc =
   Concrete {fileName; fileUri; modulePath = []; typeName; loc}
 
+let isGraphQLNameStart character =
+  let code = Char.code character in
+  character = '_'
+  || (code >= Char.code 'A' && code <= Char.code 'Z')
+  || (code >= Char.code 'a' && code <= Char.code 'z')
+
+let isGraphQLNameContinue character =
+  let code = Char.code character in
+  isGraphQLNameStart character
+  || (code >= Char.code '0' && code <= Char.code '9')
+
+let isValidGraphQLName name =
+  let length = String.length name in
+  length > 0
+  && isGraphQLNameStart name.[0]
+  && String.to_seq name |> Seq.for_all isGraphQLNameContinue
+
 let validateName ~name ~(typeLocation : typeLocation)
     (schemaState : schemaState) =
   match typeLocation with
   | Synthetic _ -> ()
   | Concrete typeLocation ->
-    if Utils.startsWith name "__" then
+    if not (isValidGraphQLName name) then
+      schemaState
+      |> addDiagnostic
+           ~diagnostic:
+             {
+               loc = typeLocation.loc;
+               fileUri = typeLocation.fileUri;
+               message =
+                 Printf.sprintf
+                   "Name \"%s\" is not a valid GraphQL name. Names must start \
+                    with a letter or underscore and contain only letters, \
+                    digits, and underscores."
+                   name;
+             }
+    else if Utils.startsWith name "__" then
       schemaState
       |> addDiagnostic
            ~diagnostic:
@@ -103,6 +134,13 @@ let isNullableType = function
   | Nullable _ | RescriptNullable _ -> true
   | _ -> false
 
+let isGraphQLInt value =
+  try
+    let value = Int64.of_string value in
+    Int64.compare value (-2147483648L) >= 0
+    && Int64.compare value 2147483647L <= 0
+  with Failure _ -> false
+
 let rec validateConstValue ~(schemaState : schemaState) typ value =
   let expected () =
     Some
@@ -117,7 +155,7 @@ let rec validateConstValue ~(schemaState : schemaState) typ value =
   | List inner, ConstList values ->
     values |> List.find_map (validateConstValue ~schemaState inner)
   | List inner, value -> validateConstValue ~schemaState inner value
-  | Scalar Int, ConstInt _ -> None
+  | Scalar Int, ConstInt value when isGraphQLInt value -> None
   | Scalar Float, (ConstInt _ | ConstFloat _) -> None
   | Scalar String, ConstString _ -> None
   | Scalar Boolean, ConstBoolean _ -> None
@@ -209,10 +247,7 @@ let rec validateConstValue ~(schemaState : schemaState) typ value =
               | None -> None
               | Some member -> validateConstValue ~schemaState member.typ value)
       ))
-  | ( GraphQLScalar _,
-      (ConstInt _ | ConstFloat _ | ConstString _ | ConstBoolean _ | ConstEnum _)
-    ) ->
-    None
+  | GraphQLScalar _, _ -> None
   | EmptyPayload, ConstBoolean _ -> None
   | ( ( InjectContext | InjectInfo | InjectInterfaceTypename _
       | GraphQLObjectType _ | GraphQLUnion _ | GraphQLInterface _ ),

--- a/src/ml/GenerateSchemaValidation.ml
+++ b/src/ml/GenerateSchemaValidation.ml
@@ -276,6 +276,17 @@ let validateDirectiveDefinitions (schemaState : schemaState) =
                       redefined."
                      definition.name;
                };
+      if definition.name = "sourceLoc" then
+        schemaState
+        |> addDiagnostic
+             ~diagnostic:
+               {
+                 loc = definition.typeLocation.loc;
+                 fileUri = definition.typeLocation.fileUri;
+                 message =
+                   "`@sourceLoc` is reserved for ResGraph's generated schema \
+                    metadata and cannot be redefined.";
+               };
       let seenLocations = Hashtbl.create (List.length definition.locations) in
       definition.locations
       |> List.iter (fun location ->

--- a/src/ml/GenerateSchemaValidation.ml
+++ b/src/ml/GenerateSchemaValidation.ml
@@ -679,11 +679,25 @@ let validateSchema (schemaState : schemaState) =
 
   schemaState.types
   |> Hashtbl.iter (fun _name (typ : gqlObjectType) ->
+      (match typ.typeLocation with
+      | Some typeLocation ->
+        validateName ~name:typ.displayName ~typeLocation schemaState
+      | None -> ());
       validateFields ~schemaState ~parentTypeName:typ.displayName typ.fields);
 
   schemaState.inputObjects
   |> Hashtbl.iter (fun _name (typ : gqlInputObjectType) ->
+      (match typ.typeLocation with
+      | Some typeLocation ->
+        validateName ~name:typ.displayName
+          ~typeLocation:(Concrete typeLocation) schemaState
+      | None -> ());
       validateFields ~schemaState ~parentTypeName:typ.displayName typ.fields);
+
+  schemaState.inputUnions
+  |> Hashtbl.iter (fun _name (typ : gqlInputUnionType) ->
+      validateName ~name:typ.displayName
+        ~typeLocation:(Concrete typ.typeLocation) schemaState);
 
   schemaState.enums
   |> Hashtbl.iter (fun _name (typ : gqlEnum) ->
@@ -701,4 +715,6 @@ let validateSchema (schemaState : schemaState) =
   |> Hashtbl.iter (fun _name (typ : gqlInterface) ->
       (* Subtype rules etc for interface fields are a bit complicated, so we
             let graphql-js do it at runtime instead. *)
+      validateName ~name:typ.displayName
+        ~typeLocation:(Concrete typ.typeLocation) schemaState;
       validateFields ~schemaState ~parentTypeName:typ.displayName typ.fields)

--- a/src/ml/GenerateSchemaValidation.ml
+++ b/src/ml/GenerateSchemaValidation.ml
@@ -99,6 +99,323 @@ let rec graphqlTypeToString ?(nullable = false) (typ : graphqlType) =
   | GraphQLScalar {displayName} ->
     displayName ^ nullableSuffix
 
+let isNullableType = function
+  | Nullable _ | RescriptNullable _ -> true
+  | _ -> false
+
+let rec validateConstValue ~(schemaState : schemaState) typ value =
+  let expected () =
+    Some
+      (Printf.sprintf "Expected a value coercible to `%s`."
+         (graphqlTypeToString typ))
+  in
+  match (typ, value) with
+  | (Nullable _ | RescriptNullable _), ConstNull -> None
+  | (Nullable inner | RescriptNullable inner), value ->
+    validateConstValue ~schemaState inner value
+  | _, ConstNull -> expected ()
+  | List inner, ConstList values ->
+    values |> List.find_map (validateConstValue ~schemaState inner)
+  | List inner, value -> validateConstValue ~schemaState inner value
+  | Scalar Int, ConstInt _ -> None
+  | Scalar Float, (ConstInt _ | ConstFloat _) -> None
+  | Scalar String, ConstString _ -> None
+  | Scalar Boolean, ConstBoolean _ -> None
+  | Scalar ID, (ConstInt _ | ConstString _) -> None
+  | GraphQLEnum {id}, ConstEnum value -> (
+    match Hashtbl.find_opt schemaState.enums id with
+    | Some enum
+      when enum.values
+           |> List.exists (fun (enumValue : gqlEnumValue) ->
+               enumValue.value = value) ->
+      None
+    | Some enum ->
+      Some
+        (Printf.sprintf "`%s` is not a value of enum `%s`." value
+           enum.displayName)
+    | None -> expected ())
+  | GraphQLInputObject {id}, ConstObject fields -> (
+    match Hashtbl.find_opt schemaState.inputObjects id with
+    | None -> expected ()
+    | Some inputObject -> (
+      let unknownField =
+        fields
+        |> List.find_opt (fun (name, _) ->
+            inputObject.fields
+            |> List.exists (fun (field : gqlField) -> field.name = name)
+            |> not)
+      in
+      match unknownField with
+      | Some (name, _) ->
+        Some
+          (Printf.sprintf "Input object `%s` has no field named `%s`."
+             inputObject.displayName name)
+      | None -> (
+        let missingRequiredField =
+          inputObject.fields
+          |> List.find_opt (fun (field : gqlField) ->
+              (not (isNullableType field.typ))
+              && fields |> List.mem_assoc field.name |> not)
+        in
+        match missingRequiredField with
+        | Some field ->
+          Some
+            (Printf.sprintf "Required input field `%s.%s` is missing."
+               inputObject.displayName field.name)
+        | None ->
+          fields
+          |> List.find_map (fun (name, value) ->
+              match
+                inputObject.fields
+                |> List.find_opt (fun (field : gqlField) -> field.name = name)
+              with
+              | None -> None
+              | Some field -> validateConstValue ~schemaState field.typ value)))
+    )
+  | GraphQLInputUnion {id}, ConstObject fields -> (
+    match Hashtbl.find_opt schemaState.inputUnions id with
+    | None -> expected ()
+    | Some inputUnion -> (
+      let nonNullFields =
+        fields |> List.filter (fun (_, value) -> value <> ConstNull)
+      in
+      if List.length nonNullFields <> 1 then
+        Some
+          (Printf.sprintf
+             "OneOf input `%s` requires exactly one non-null field."
+             inputUnion.displayName)
+      else
+        let unknownField =
+          fields
+          |> List.find_opt (fun (name, _) ->
+              inputUnion.members
+              |> List.exists (fun (member : gqlInputUnionMember) ->
+                  member.fieldName = name)
+              |> not)
+        in
+        match unknownField with
+        | Some (name, _) ->
+          Some
+            (Printf.sprintf "OneOf input `%s` has no field named `%s`."
+               inputUnion.displayName name)
+        | None ->
+          nonNullFields
+          |> List.find_map (fun (name, value) ->
+              match
+                inputUnion.members
+                |> List.find_opt (fun (member : gqlInputUnionMember) ->
+                    member.fieldName = name)
+              with
+              | None -> None
+              | Some member -> validateConstValue ~schemaState member.typ value)
+      ))
+  | ( GraphQLScalar _,
+      (ConstInt _ | ConstFloat _ | ConstString _ | ConstBoolean _ | ConstEnum _)
+    ) ->
+    None
+  | EmptyPayload, ConstBoolean _ -> None
+  | ( ( InjectContext | InjectInfo | InjectInterfaceTypename _
+      | GraphQLObjectType _ | GraphQLUnion _ | GraphQLInterface _ ),
+      _ ) ->
+    expected ()
+  | _ -> expected ()
+
+let validateDirectiveDefinitions (schemaState : schemaState) =
+  let reservedNames =
+    ["skip"; "include"; "deprecated"; "specifiedBy"; "oneOf"]
+  in
+  schemaState.directiveDefinitions
+  |> Hashtbl.iter (fun _name (definition : gqlDirectiveDefinition) ->
+      validateName ~name:definition.name
+        ~typeLocation:(Concrete definition.typeLocation) schemaState;
+      if List.mem definition.name reservedNames then
+        schemaState
+        |> addDiagnostic
+             ~diagnostic:
+               {
+                 loc = definition.typeLocation.loc;
+                 fileUri = definition.typeLocation.fileUri;
+                 message =
+                   Printf.sprintf
+                     "`@%s` is a GraphQL-specified directive and cannot be \
+                      redefined."
+                     definition.name;
+               };
+      let seenLocations = Hashtbl.create (List.length definition.locations) in
+      definition.locations
+      |> List.iter (fun location ->
+          if Hashtbl.mem seenLocations location then
+            schemaState
+            |> addDiagnostic
+                 ~diagnostic:
+                   {
+                     loc = definition.typeLocation.loc;
+                     fileUri = definition.typeLocation.fileUri;
+                     message =
+                       Printf.sprintf
+                         "Directive `@%s` declares location `%s` more than \
+                          once."
+                         definition.name
+                         (GenerateSchemaDirectiveUtils.locationToString location);
+                   }
+          else Hashtbl.add seenLocations location ());
+      definition.arguments
+      |> List.iter (fun (argument : gqlDirectiveArgument) ->
+          validateName ~name:argument.name
+            ~typeLocation:
+              (mkTypeLocation ~typeName:argument.name
+                 ~fileName:definition.typeLocation.fileName
+                 ~fileUri:definition.typeLocation.fileUri ~loc:argument.loc)
+            schemaState;
+          (match argument.defaultValue with
+          | None -> ()
+          | Some value -> (
+            match validateConstValue ~schemaState argument.typ value with
+            | None -> ()
+            | Some message ->
+              schemaState
+              |> addDiagnostic
+                   ~diagnostic:
+                     {
+                       loc = argument.loc;
+                       fileUri = definition.typeLocation.fileUri;
+                       message =
+                         Printf.sprintf
+                           "Invalid default for directive argument `@%s(%s:)`: \
+                            %s"
+                           definition.name argument.name message;
+                     }));
+          if
+            Option.is_some argument.deprecationReason
+            && (not (isNullableType argument.typ))
+            && Option.is_none argument.defaultValue
+          then
+            schemaState
+            |> addDiagnostic
+                 ~diagnostic:
+                   {
+                     loc = argument.loc;
+                     fileUri = definition.typeLocation.fileUri;
+                     message =
+                       Printf.sprintf
+                         "Required directive argument `@%s(%s:)` cannot be \
+                          deprecated without a default value."
+                         definition.name argument.name;
+                   }))
+
+let validateDirectiveApplications (schemaState : schemaState) =
+  schemaState.appliedDirectives
+  |> Hashtbl.iter (fun target applications ->
+      let counts = Hashtbl.create (List.length applications) in
+      applications
+      |> List.iter (fun (application : gqlDirectiveApplication) ->
+          match
+            Hashtbl.find_opt schemaState.directiveDefinitions application.name
+          with
+          | None ->
+            schemaState
+            |> addDiagnostic
+                 ~diagnostic:
+                   {
+                     loc = application.loc;
+                     fileUri = application.fileUri;
+                     message =
+                       Printf.sprintf
+                         "Directive `@%s` is not defined in this schema."
+                         application.name;
+                   }
+          | Some definition ->
+            let location =
+              GenerateSchemaDirectiveUtils.locationForTarget target
+            in
+            if not (List.mem location definition.locations) then
+              schemaState
+              |> addDiagnostic
+                   ~diagnostic:
+                     {
+                       loc = application.loc;
+                       fileUri = application.fileUri;
+                       message =
+                         Printf.sprintf
+                           "Directive `@%s` cannot be used on `%s`; its \
+                            definition does not include `%s`."
+                           application.name
+                           (GenerateSchemaDirectiveUtils.targetToString target)
+                           (GenerateSchemaDirectiveUtils.locationToString
+                              location);
+                     };
+            let previousCount =
+              Hashtbl.find_opt counts application.name
+              |> Option.value ~default:0
+            in
+            Hashtbl.replace counts application.name (previousCount + 1);
+            if previousCount > 0 && not definition.repeatable then
+              schemaState
+              |> addDiagnostic
+                   ~diagnostic:
+                     {
+                       loc = application.loc;
+                       fileUri = application.fileUri;
+                       message =
+                         Printf.sprintf
+                           "Directive `@%s` is not repeatable on `%s`."
+                           application.name
+                           (GenerateSchemaDirectiveUtils.targetToString target);
+                     };
+            application.arguments
+            |> List.iter (fun (name, value) ->
+                match
+                  definition.arguments
+                  |> List.find_opt (fun (argument : gqlDirectiveArgument) ->
+                      argument.name = name)
+                with
+                | None ->
+                  schemaState
+                  |> addDiagnostic
+                       ~diagnostic:
+                         {
+                           loc = application.loc;
+                           fileUri = application.fileUri;
+                           message =
+                             Printf.sprintf
+                               "Directive `@%s` has no argument named `%s`."
+                               application.name name;
+                         }
+                | Some argument -> (
+                  match validateConstValue ~schemaState argument.typ value with
+                  | None -> ()
+                  | Some message ->
+                    schemaState
+                    |> addDiagnostic
+                         ~diagnostic:
+                           {
+                             loc = application.loc;
+                             fileUri = application.fileUri;
+                             message =
+                               Printf.sprintf "Invalid value for `@%s(%s:)`: %s"
+                                 application.name name message;
+                           }));
+            definition.arguments
+            |> List.iter (fun (argument : gqlDirectiveArgument) ->
+                if
+                  (not (isNullableType argument.typ))
+                  && Option.is_none argument.defaultValue
+                  && application.arguments
+                     |> List.mem_assoc argument.name
+                     |> not
+                then
+                  schemaState
+                  |> addDiagnostic
+                       ~diagnostic:
+                         {
+                           loc = application.loc;
+                           fileUri = application.fileUri;
+                           message =
+                             Printf.sprintf
+                               "Directive `@%s` requires argument `%s`."
+                               application.name argument.name;
+                         })))
+
 let nullableInner (typ : graphqlType) =
   match typ with
   | Nullable inner | RescriptNullable inner -> Some inner
@@ -317,6 +634,8 @@ let validateInterfaceImplementationCycles (schemaState : schemaState) =
 let validateSchema (schemaState : schemaState) =
   validateRootTypes schemaState;
   validateInterfaceImplementationCycles schemaState;
+  validateDirectiveDefinitions schemaState;
+  validateDirectiveApplications schemaState;
 
   schemaState.scalars
   |> Hashtbl.iter (fun _name (typ : gqlScalar) ->

--- a/src/ml/dune
+++ b/src/ml/dune
@@ -6,10 +6,10 @@
   (-w "+6+26+27+32+33+39"))
  (libraries unix str ext ml jsonlib syntax)
  (modules Cli CodeWriter GenerateSchema GenerateSchemaDirect
-   GenerateSchemaTypes GenerateSchemaAuthorization GenerateSchemaUtils
-   GenerateSchemaDiagnostics GenerateSchemaSDL GenerateSchemaCache
-   GenerateSchemaValidation GenerateSchemaTypePrinters ProcessAttributes
-   TypeUtils Shared SharedTypes Utils Loc Pos Range Uri Files Packages
-   ModuleResolution BuildSystem Cache Cfg CmtDirect CmtSummarize
-   DirectResolve DirectReferences Debug Log PrintType Protocol References
-   Completion Hover Analyze Markdown FindFiles))
+   GenerateSchemaTypes GenerateSchemaDirectiveUtils
+   GenerateSchemaAuthorization GenerateSchemaUtils GenerateSchemaDiagnostics
+   GenerateSchemaSDL GenerateSchemaCache GenerateSchemaValidation
+   GenerateSchemaTypePrinters ProcessAttributes TypeUtils Shared SharedTypes
+   Utils Loc Pos Range Uri Files Packages ModuleResolution BuildSystem Cache
+   Cfg CmtDirect CmtSummarize DirectResolve DirectReferences Debug Log
+   PrintType Protocol References Completion Hover Analyze Markdown FindFiles))

--- a/src/res/ResGraph__GraphQLJs.mjs
+++ b/src/res/ResGraph__GraphQLJs.mjs
@@ -3,6 +3,8 @@
 
 let GraphQLLiteralValue = {};
 
+let GraphQLInput = {};
+
 let AstNode = {};
 
 let Scalars = {};
@@ -27,6 +29,7 @@ let GraphQLSchemaType = {};
 
 export {
   GraphQLLiteralValue,
+  GraphQLInput,
   AstNode,
   Scalars,
   GraphQLDirective,

--- a/src/res/ResGraph__GraphQLJs.mjs
+++ b/src/res/ResGraph__GraphQLJs.mjs
@@ -3,6 +3,22 @@
 
 let GraphQLLiteralValue = {};
 
+let makeLazyDirectiveArguments = (function makeLazyDirectiveArguments(thunks) {
+    const result = {};
+    Object.entries(thunks).forEach(([name, thunk]) => {
+      Object.defineProperty(result, name, {
+        configurable: true,
+        enumerable: true,
+        get() {
+          const value = thunk();
+          Object.defineProperty(result, name, {enumerable: true, value});
+          return value;
+        },
+      });
+    });
+    return result;
+  });
+
 let GraphQLInput = {};
 
 let AstNode = {};
@@ -29,6 +45,7 @@ let GraphQLSchemaType = {};
 
 export {
   GraphQLLiteralValue,
+  makeLazyDirectiveArguments,
   GraphQLInput,
   AstNode,
   Scalars,

--- a/src/res/ResGraph__GraphQLJs.mjs
+++ b/src/res/ResGraph__GraphQLJs.mjs
@@ -7,6 +7,8 @@ let AstNode = {};
 
 let Scalars = {};
 
+let GraphQLDirective = {};
+
 let GraphQLInterfaceType = {};
 
 let GraphQLScalar = {};
@@ -27,6 +29,7 @@ export {
   GraphQLLiteralValue,
   AstNode,
   Scalars,
+  GraphQLDirective,
   GraphQLInterfaceType,
   GraphQLScalar,
   GraphQLObjectType,

--- a/src/res/ResGraph__GraphQLJs.res
+++ b/src/res/ResGraph__GraphQLJs.res
@@ -12,6 +12,16 @@ module GraphQLLiteralValue = {
     | Array(array<t>)
 }
 
+type directiveArguments = Dict.t<GraphQLLiteralValue.t>
+type directiveMap = Dict.t<array<directiveArguments>>
+type appliedDirective = {name: string, args: directiveArguments}
+type resgraphDirectiveExtensions = {appliedDirectives: array<appliedDirective>}
+type directiveExtensions = {
+  directives?: directiveMap,
+  resgraph?: resgraphDirectiveExtensions,
+  oneOf?: bool,
+}
+
 type graphqlType
 
 @module("graphql") @new external nonNull: graphqlType => graphqlType = "GraphQLNonNull"
@@ -40,7 +50,13 @@ module Scalars = {
   @module("graphql") @val external boolean: t = "GraphQLBoolean"
 }
 
-type arg = {@as("type") typ: graphqlType}
+type arg = {
+  @as("type") typ: graphqlType,
+  defaultValue?: GraphQLLiteralValue.t,
+  description?: string,
+  deprecationReason?: string,
+  extensions?: directiveExtensions,
+}
 
 type resolveFn
 
@@ -53,6 +69,7 @@ external makeFields: {..} => fields = "%identity"
 type args
 
 external makeArgs: {..} => args = "%identity"
+external makeArgsDict: Dict.t<arg> => args = "%identity"
 
 type typeField = {
   @as("type") typ: graphqlType,
@@ -61,6 +78,22 @@ type typeField = {
   description?: string,
   deprecationReason?: string,
   subscribe?: resolveFn,
+  extensions?: directiveExtensions,
+}
+
+module GraphQLDirective = {
+  type t
+
+  type config = {
+    name: string,
+    description?: string,
+    locations: array<string>,
+    args?: args,
+    isRepeatable?: bool,
+  }
+
+  @module("graphql") @new external make: config => t = "GraphQLDirective"
+  @module("graphql") @val external specifiedDirectives: array<t> = "specifiedDirectives"
 }
 
 module GraphQLInterfaceType = {
@@ -79,6 +112,7 @@ module GraphQLInterfaceType = {
     fields: unit => fields,
     resolveType: resolveInterfaceTypeFn,
     interfaces?: array<t>,
+    extensions?: directiveExtensions,
   }
   @module("graphql") @new external make: config => t = "GraphQLInterfaceType"
 }
@@ -93,6 +127,8 @@ module GraphQLScalar = {
     description?: string,
     parseValue?: GraphQLLiteralValue.t => option<'t>,
     serialize?: 't => GraphQLLiteralValue.t,
+    specifiedByURL?: string,
+    extensions?: directiveExtensions,
   }
   @module("graphql") @new external make: config<_> => t = "GraphQLScalarType"
 }
@@ -108,6 +144,7 @@ module GraphQLObjectType = {
     description?: string,
     fields: unit => fields,
     interfaces?: array<GraphQLInterfaceType.t>,
+    extensions?: directiveExtensions,
   }
   @module("graphql") @new external make: config => t = "GraphQLObjectType"
 }
@@ -121,16 +158,15 @@ module GraphQLInputObjectType = {
     @as("type") typ: graphqlType,
     description?: string,
     deprecationReason?: string,
+    extensions?: directiveExtensions,
   }
-
-  type extensions = {oneOf?: bool}
 
   type config = {
     name: string,
     astNode?: AstNode.t,
     description?: string,
     fields: unit => fields,
-    extensions?: extensions,
+    extensions?: directiveExtensions,
   }
   @module("graphql") @new external make: config => t = "GraphQLInputObjectType"
 }
@@ -158,6 +194,7 @@ module GraphQLUnionType = {
     types: unit => array<GraphQLObjectType.t>,
     resolveType: resolveUnionTypeFn,
     description?: string,
+    extensions?: directiveExtensions,
   }
   @module("graphql") @new external make: config => t = "GraphQLUnionType"
 }
@@ -175,6 +212,7 @@ module GraphQLEnumType = {
     value?: string,
     deprecationReason?: string,
     description?: string,
+    extensions?: directiveExtensions,
   }
 
   type config = {
@@ -182,6 +220,7 @@ module GraphQLEnumType = {
     astNode?: AstNode.t,
     values: enumValues,
     description?: string,
+    extensions?: directiveExtensions,
   }
   @module("graphql") @new external make: config => t = "GraphQLEnumType"
 }
@@ -189,8 +228,19 @@ module GraphQLEnumType = {
 module GraphQLSchemaType = {
   type t<'appContext>
 
-  @module("graphql") @new
-  external make: {..} => t<_> = "GraphQLSchema"
+  type config = {
+    query: GraphQLObjectType.t,
+    mutation?: GraphQLObjectType.t,
+    subscription?: GraphQLObjectType.t,
+    types?: array<graphqlType>,
+    directives?: array<GraphQLDirective.t>,
+    extensions?: directiveExtensions,
+  }
+
+  // Keep the legacy open-object constructor so previously generated schemas
+  // still compile during an upgrade. New codegen uses the typed constructor.
+  @module("graphql") @new external make: {..} => t<_> = "GraphQLSchema"
+  @module("graphql") @new external makeConfig: config => t<_> = "GraphQLSchema"
 
   @module("graphql") external print: t<_> => string = "printSchema"
 }

--- a/src/res/ResGraph__GraphQLJs.res
+++ b/src/res/ResGraph__GraphQLJs.res
@@ -24,6 +24,12 @@ type directiveExtensions = {
 
 type graphqlType
 
+module GraphQLInput = {
+  @module("graphql")
+  external coerceValue: (GraphQLLiteralValue.t, graphqlType) => GraphQLLiteralValue.t =
+    "coerceInputValue"
+}
+
 @module("graphql") @new external nonNull: graphqlType => graphqlType = "GraphQLNonNull"
 
 module AstNode = {

--- a/src/res/ResGraph__GraphQLJs.res
+++ b/src/res/ResGraph__GraphQLJs.res
@@ -14,6 +14,26 @@ module GraphQLLiteralValue = {
 
 type directiveArguments = Dict.t<GraphQLLiteralValue.t>
 type directiveMap = Dict.t<array<directiveArguments>>
+type directiveArgumentThunk = unit => GraphQLLiteralValue.t
+
+let makeLazyDirectiveArguments: Dict.t<directiveArgumentThunk> => directiveArguments = %raw(`
+  function makeLazyDirectiveArguments(thunks) {
+    const result = {};
+    Object.entries(thunks).forEach(([name, thunk]) => {
+      Object.defineProperty(result, name, {
+        configurable: true,
+        enumerable: true,
+        get() {
+          const value = thunk();
+          Object.defineProperty(result, name, {enumerable: true, value});
+          return value;
+        },
+      });
+    });
+    return result;
+  }
+`)
+
 type appliedDirective = {name: string, args: directiveArguments}
 type resgraphDirectiveExtensions = {appliedDirectives: array<appliedDirective>}
 type directiveExtensions = {

--- a/tests/invalid-directives.sh
+++ b/tests/invalid-directives.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cleanup_all() {
+  rm -rf .tmp-directive-*.??????
+}
+trap cleanup_all EXIT
+
+run_fixture() {
+  local name="$1"
+  local expected="$2"
+  local tmp_dir
+  tmp_dir="$(mktemp -d ".tmp-directive-${name}.XXXXXX")"
+
+  cleanup() {
+    rm -rf "$tmp_dir"
+  }
+  trap cleanup RETURN
+
+  mkdir -p "$tmp_dir/src"
+
+  cat > "$tmp_dir/rescript.json" <<'JSON'
+{
+  "name": "resgraph-invalid-directive-test",
+  "uncurried": true,
+  "package-specs": {
+    "in-source": true,
+    "module": "esmodule",
+    "suffix": ".mjs"
+  },
+  "sources": [
+    {"dir": "../../src/res", "subdirs": true},
+    {"dir": "src", "subdirs": true}
+  ],
+  "compiler-flags": ["-w -33-44"],
+  "dependencies": ["@glennsl/rescript-fetch", "rescript-nodejs"]
+}
+JSON
+
+  cat > "$tmp_dir/src/Query.res" <<'RES'
+@gql.type
+type query
+RES
+
+  cat > "$tmp_dir/src/ResGraphContext.res" <<'RES'
+type t = unit
+RES
+
+  cat > "$tmp_dir/src/App.res" <<'RES'
+@@warning("-32")
+
+RES
+  cat >> "$tmp_dir/src/App.res"
+
+  (
+    cd "$tmp_dir"
+    ../node_modules/.bin/rescript
+  )
+
+  local output
+  set +e
+  output="$(../bin/dev/resgraph.exe generate-schema "$tmp_dir/src" "$tmp_dir/src/__generated__" true)"
+  set -e
+
+  if ! printf "%s" "$output" | grep -q '"status": "Error"'; then
+    printf "Expected directive fixture %s to fail, but it succeeded.\n%s\n" "$name" "$output"
+    exit 1
+  fi
+
+  if ! printf "%s" "$output" | grep -q "$expected"; then
+    printf "Expected directive fixture %s to include diagnostic %s, got:\n%s\n" "$name" "$expected" "$output"
+    exit 1
+  fi
+}
+
+run_fixture "unknown" 'Directive `@missing` is not defined' <<'RES'
+@gql.annotate({name: "missing"})
+@gql.type
+type broken = {@gql.field value: string}
+
+@gql.field
+let broken = (_: Query.query): broken => {value: "broken"}
+RES
+
+run_fixture "wrong-location" 'does not include `OBJECT`' <<'RES'
+@gql.directive({locations: ["FIELD_DEFINITION"]})
+type fieldOnly
+
+@gql.annotate({name: "fieldOnly"})
+@gql.type
+type broken = {@gql.field value: string}
+
+@gql.field
+let broken = (_: Query.query): broken => {value: "broken"}
+RES
+
+run_fixture "missing-argument" 'requires argument `value`' <<'RES'
+@gql.directive({locations: ["OBJECT"]})
+type requiresValue = {value: int}
+
+@gql.annotate({name: "requiresValue"})
+@gql.type
+type broken = {@gql.field value: string}
+
+@gql.field
+let broken = (_: Query.query): broken => {value: "broken"}
+RES
+
+run_fixture "wrong-argument-type" 'Invalid value for `@typed(value:)`' <<'RES'
+@gql.directive({locations: ["OBJECT"]})
+type typed = {value: int}
+
+@gql.annotate({name: "typed", args: {value: "not-an-int"}})
+@gql.type
+type broken = {@gql.field value: string}
+
+@gql.field
+let broken = (_: Query.query): broken => {value: "broken"}
+RES
+
+run_fixture "not-repeatable" 'Directive `@once` is not repeatable' <<'RES'
+@gql.directive({locations: ["OBJECT"]})
+type once
+
+@gql.annotate({name: "once"})
+@gql.annotate({name: "once"})
+@gql.type
+type broken = {@gql.field value: string}
+
+@gql.field
+let broken = (_: Query.query): broken => {value: "broken"}
+RES
+
+run_fixture "invalid-location" 'is not a GraphQL directive location' <<'RES'
+@gql.directive({locations: ["OBJECTISH"]})
+type invalidLocation
+RES

--- a/tests/invalid-directives.sh
+++ b/tests/invalid-directives.sh
@@ -136,6 +136,12 @@ run_fixture "invalid-location" 'is not a GraphQL directive location' <<'RES'
 type invalidLocation
 RES
 
+run_fixture "duplicate-directive-annotation" 'Only one `@gql.directive` annotation is allowed' <<'RES'
+@gql.directive({locations: ["OBJECT"]})
+@gql.directive({locations: ["FIELD_DEFINITION"]})
+type duplicateDirective
+RES
+
 run_fixture "invalid-name" 'is not a valid GraphQL name' <<'RES'
 @as("invalid-name")
 @gql.directive({locations: ["OBJECT"]})

--- a/tests/invalid-directives.sh
+++ b/tests/invalid-directives.sh
@@ -47,7 +47,7 @@ type t = unit
 RES
 
   cat > "$tmp_dir/src/App.res" <<'RES'
-@@warning("-32")
+@@warning("-32-101")
 
 RES
   cat >> "$tmp_dir/src/App.res"
@@ -134,4 +134,18 @@ RES
 run_fixture "invalid-location" 'is not a GraphQL directive location' <<'RES'
 @gql.directive({locations: ["OBJECTISH"]})
 type invalidLocation
+RES
+
+run_fixture "invalid-name" 'is not a valid GraphQL name' <<'RES'
+@as("invalid-name")
+@gql.directive({locations: ["OBJECT"]})
+type invalidName
+RES
+
+run_fixture "int-out-of-range" 'Invalid default for directive argument' <<'RES'
+@gql.directive({locations: ["OBJECT"]})
+type invalidInt = {
+  @gql.default(2147483648)
+  value: int,
+}
 RES

--- a/tests/invalid-directives.sh
+++ b/tests/invalid-directives.sh
@@ -148,6 +148,12 @@ run_fixture "invalid-name" 'is not a valid GraphQL name' <<'RES'
 type invalidName
 RES
 
+run_fixture "reserved-source-loc" '`@sourceLoc` is reserved for ResGraph' <<'RES'
+@as("sourceLoc")
+@gql.directive({locations: ["OBJECT"]})
+type internalDirectiveName
+RES
+
 run_fixture "int-out-of-range" 'Invalid default for directive argument' <<'RES'
 @gql.directive({locations: ["OBJECT"]})
 type invalidInt = {

--- a/tests/multi-schema/package-a/src/generated/PackageASchema.res
+++ b/tests/multi-schema/package-a/src/generated/PackageASchema.res
@@ -106,9 +106,9 @@ t_Query.contents = GraphQLObjectType.make({
   }->makeFields
 })
 
-let schema = GraphQLSchemaType.make({
-  "query": get_Query(),
-  "types": [
+let schema = GraphQLSchemaType.makeConfig({
+  query: get_Query(),
+  types: [
     get_Query()->GraphQLObjectType.toGraphQLType
   ]
 })

--- a/tests/multi-schema/package-a/src/generated/ResGraphSchema.res
+++ b/tests/multi-schema/package-a/src/generated/ResGraphSchema.res
@@ -104,9 +104,9 @@ t_Query.contents = GraphQLObjectType.make({
   }->makeFields
 })
 
-let schema = GraphQLSchemaType.make({
-  "query": get_Query(),
-  "types": [
+let schema = GraphQLSchemaType.makeConfig({
+  query: get_Query(),
+  types: [
     get_Query()->GraphQLObjectType.toGraphQLType
   ]
 })

--- a/tests/multi-schema/package-b/src/generated/PackageBSchema.res
+++ b/tests/multi-schema/package-b/src/generated/PackageBSchema.res
@@ -106,9 +106,9 @@ t_Query.contents = GraphQLObjectType.make({
   }->makeFields
 })
 
-let schema = GraphQLSchemaType.make({
-  "query": get_Query(),
-  "types": [
+let schema = GraphQLSchemaType.makeConfig({
+  query: get_Query(),
+  types: [
     get_Query()->GraphQLObjectType.toGraphQLType
   ]
 })

--- a/tests/multi-schema/src/generated/admin/AdminSchema.res
+++ b/tests/multi-schema/src/generated/admin/AdminSchema.res
@@ -156,9 +156,9 @@ t_SharedItem.contents = GraphQLObjectType.make({
   }->makeFields
 })
 
-let schema = GraphQLSchemaType.make({
-  "query": get_Query(),
-  "types": [
+let schema = GraphQLSchemaType.makeConfig({
+  query: get_Query(),
+  types: [
     get_Query()->GraphQLObjectType.toGraphQLType,
     get_SharedItem()->GraphQLObjectType.toGraphQLType,
     get_Entity()->GraphQLInterfaceType.toGraphQLType

--- a/tests/multi-schema/src/generated/public/PublicSchema.res
+++ b/tests/multi-schema/src/generated/public/PublicSchema.res
@@ -156,9 +156,9 @@ t_SharedItem.contents = GraphQLObjectType.make({
   }->makeFields
 })
 
-let schema = GraphQLSchemaType.make({
-  "query": get_Query(),
-  "types": [
+let schema = GraphQLSchemaType.makeConfig({
+  query: get_Query(),
+  types: [
     get_Query()->GraphQLObjectType.toGraphQLType,
     get_SharedItem()->GraphQLObjectType.toGraphQLType,
     get_Entity()->GraphQLInterfaceType.toGraphQLType

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -15,6 +15,7 @@
         "rescript-nodejs": "^16.1.0"
       },
       "devDependencies": {
+        "@graphql-tools/utils": "^11.2.2",
         "@rescript/react": "^0.14.0",
         "nodemon": "^2.0.22"
       }
@@ -65,12 +66,48 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@graphql-tools/executor/node_modules/@graphql-tools/utils": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+      "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@graphql-tools/merge": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.3.tgz",
       "integrity": "sha512-FeKv9lKLMwqDu0pQjPpF59GY3HReUkWXKsMIuMuJQOKh9BETu7zPEFUELvcw8w+lwZkl4ileJsHXC9+AnsT2Lw==",
       "dependencies": {
         "@graphql-tools/utils": "^10.0.13",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+      "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -97,14 +134,34 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/utils": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.1.3.tgz",
-      "integrity": "sha512-loco2ctrrMQzdpSHbcOo6+Ecp21BV67cQ2pNGhuVKAexruu01RdLn3LgtK47B9BpLz3cUD6U0u1R0rur7xMOOg==",
+    "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+      "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "cross-inspect": "1.0.0",
-        "dset": "^3.1.2",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+      "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -295,6 +352,18 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@whatwg-node/server": {
       "version": "0.9.33",
       "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.9.33.tgz",
@@ -408,9 +477,10 @@
       "dev": true
     },
     "node_modules/cross-inspect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.0.tgz",
-      "integrity": "sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -507,6 +577,24 @@
       },
       "peerDependencies": {
         "graphql": "^15.2.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-yoga/node_modules/@graphql-tools/utils": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+      "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/has-flag": {
@@ -832,9 +920,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",
@@ -889,6 +978,19 @@
         "@repeaterjs/repeater": "^3.0.4",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "10.11.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+          "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@graphql-tools/merge": {
@@ -898,6 +1000,19 @@
       "requires": {
         "@graphql-tools/utils": "^10.0.13",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "10.11.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+          "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@graphql-tools/schema": {
@@ -909,16 +1024,30 @@
         "@graphql-tools/utils": "^10.0.13",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "10.11.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+          "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@graphql-tools/utils": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.1.3.tgz",
-      "integrity": "sha512-loco2ctrrMQzdpSHbcOo6+Ecp21BV67cQ2pNGhuVKAexruu01RdLn3LgtK47B9BpLz3cUD6U0u1R0rur7xMOOg==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+      "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
+      "dev": true,
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "cross-inspect": "1.0.0",
-        "dset": "^3.1.2",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
         "tslib": "^2.4.0"
       }
     },
@@ -1034,6 +1163,14 @@
         "tslib": "^2.3.1"
       }
     },
+    "@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "requires": {
+        "tslib": "^2.6.3"
+      }
+    },
     "@whatwg-node/server": {
       "version": "0.9.33",
       "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.9.33.tgz",
@@ -1121,9 +1258,9 @@
       "dev": true
     },
     "cross-inspect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.0.tgz",
-      "integrity": "sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
       "requires": {
         "tslib": "^2.4.0"
       }
@@ -1192,6 +1329,19 @@
         "dset": "^3.1.1",
         "lru-cache": "^10.0.0",
         "tslib": "^2.5.2"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "10.11.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+          "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
+            "@whatwg-node/promise-helpers": "^1.0.0",
+            "cross-inspect": "1.0.1",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "has-flag": {
@@ -1419,9 +1569,9 @@
       }
     },
     "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "undefsafe": {
       "version": "2.0.5",

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,6 +8,7 @@
   },
   "private": true,
   "devDependencies": {
+    "@graphql-tools/utils": "^11.2.2",
     "@rescript/react": "^0.14.0",
     "nodemon": "^2.0.22"
   },

--- a/tests/runtime-directives.mjs
+++ b/tests/runtime-directives.mjs
@@ -20,6 +20,9 @@ assert.equal(
   'Use "scope" instead.',
 );
 
+const identifies = schema.getDirective("identifies");
+assert.equal(identifies.args.find(argument => argument.name === "value").defaultValue, "123");
+
 const tag = schema.getDirective("tag");
 assert.ok(tag);
 assert.equal(tag.isRepeatable, true);
@@ -31,12 +34,16 @@ assert.deepEqual(plain(getDirective(schema, directiveExample, "tag")), [
 ]);
 assert.deepEqual(
   getDirectives(schema, directiveExample).map(directive => directive.name),
-  ["tag", "tag", "cacheControl"],
+  ["identifies", "tag", "tag", "cacheControl"],
 );
 assert.deepEqual(plain(directiveExample.extensions.resgraph.appliedDirectives), [
+  { name: "identifies", args: { value: "456" } },
   { name: "tag", args: { name: "first" } },
   { name: "cacheControl", args: { maxAge: 30 } },
   { name: "tag", args: { name: "second" } },
+]);
+assert.deepEqual(plain(getDirective(schema, directiveExample, "identifies")), [
+  {value: "456"},
 ]);
 
 const valueField = directiveExample.getFields().value;

--- a/tests/runtime-directives.mjs
+++ b/tests/runtime-directives.mjs
@@ -54,6 +54,9 @@ assert.deepEqual(plain(getDirective(schema, valueField, "cacheControl")), [
 const uuid = schema.getType("Uuid");
 assert.equal(uuid.specifiedByURL, "https://example.com/specifiedBy/uuid");
 assert.deepEqual(plain(getDirective(schema, uuid, "tag")), [{ name: "scalar" }]);
+assert.deepEqual(plain(getDirective(schema, uuid, "scalarMetadata")), [
+  {config: {label: "deferred"}, tier: "Premium"},
+]);
 
 const result = await execute({
   schema,

--- a/tests/runtime-directives.mjs
+++ b/tests/runtime-directives.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { getDirective, getDirectives } from "@graphql-tools/utils";
+import { execute, parse, validateSchema } from "graphql";
+import { schema } from "./src/__generated__/ResGraphSchema.mjs";
+
+const plain = value => JSON.parse(JSON.stringify(value));
+
+assert.doesNotThrow(() => parse(readFileSync("./src/__generated__/schema.graphql", "utf8")));
+assert.deepEqual(validateSchema(schema), []);
+
+const cacheControl = schema.getDirective("cacheControl");
+assert.ok(cacheControl);
+assert.deepEqual(cacheControl.locations, ["OBJECT", "FIELD_DEFINITION"]);
+assert.equal(cacheControl.isRepeatable, false);
+assert.equal(cacheControl.args.find(argument => argument.name === "maxAge").defaultValue, 60);
+assert.equal(
+  cacheControl.args.find(argument => argument.name === "legacyScope").deprecationReason,
+  "Use scope instead.",
+);
+
+const tag = schema.getDirective("tag");
+assert.ok(tag);
+assert.equal(tag.isRepeatable, true);
+
+const directiveExample = schema.getType("DirectiveExample");
+assert.deepEqual(plain(getDirective(schema, directiveExample, "tag")), [
+  { name: "first" },
+  { name: "second" },
+]);
+assert.deepEqual(
+  getDirectives(schema, directiveExample).map(directive => directive.name),
+  ["tag", "tag", "cacheControl"],
+);
+assert.deepEqual(plain(directiveExample.extensions.resgraph.appliedDirectives), [
+  { name: "tag", args: { name: "first" } },
+  { name: "cacheControl", args: { maxAge: 30 } },
+  { name: "tag", args: { name: "second" } },
+]);
+
+const valueField = directiveExample.getFields().value;
+assert.deepEqual(plain(getDirective(schema, valueField, "cacheControl")), [
+  { maxAge: 10, scope: "private" },
+]);
+
+const uuid = schema.getType("Uuid");
+assert.equal(uuid.specifiedByURL, "https://example.com/specifiedBy/uuid");
+assert.deepEqual(plain(getDirective(schema, uuid, "tag")), [{ name: "scalar" }]);
+
+const result = await execute({
+  schema,
+  document: parse(`
+    query DirectiveExample($input: DirectiveInput!) {
+      directiveExample(input: $input) {
+        value
+        status
+      }
+    }
+  `),
+  variableValues: { input: { value: "directives work" } },
+});
+
+assert.equal(result.errors, undefined);
+assert.deepEqual(plain(result.data), {
+  directiveExample: { value: "directives work", status: "Active" },
+});
+
+console.log("✅ Directive definitions, metadata, ordering, and execution work.");

--- a/tests/runtime-directives.mjs
+++ b/tests/runtime-directives.mjs
@@ -11,12 +11,13 @@ assert.deepEqual(validateSchema(schema), []);
 
 const cacheControl = schema.getDirective("cacheControl");
 assert.ok(cacheControl);
+assert.equal(cacheControl.description, 'Caching metadata consumed by a """schema transform""".');
 assert.deepEqual(cacheControl.locations, ["OBJECT", "FIELD_DEFINITION"]);
 assert.equal(cacheControl.isRepeatable, false);
 assert.equal(cacheControl.args.find(argument => argument.name === "maxAge").defaultValue, 60);
 assert.equal(
   cacheControl.args.find(argument => argument.name === "legacyScope").deprecationReason,
-  "Use scope instead.",
+  'Use "scope" instead.',
 );
 
 const tag = schema.getDirective("tag");

--- a/tests/src/AppCustomScalars.res
+++ b/tests/src/AppCustomScalars.res
@@ -1,5 +1,6 @@
 /** Custom scalar with specifiedByUrl coverage. */
 @specifiedBy("https://example.com/specifiedBy/uuid")
+@gql.annotate({name: "tag", args: {name: "scalar"}})
 @gql.scalar
 type uuid = string
 // ^hov

--- a/tests/src/AppCustomScalars.res
+++ b/tests/src/AppCustomScalars.res
@@ -1,5 +1,18 @@
+@gql.inputObject
+type scalarMetadataInput = {label: string}
+
+@gql.enum
+type scalarTier = Premium
+
+@gql.directive({locations: ["SCALAR"]})
+type scalarMetadata = {config: scalarMetadataInput, tier: scalarTier}
+
 /** Custom scalar with specifiedByUrl coverage. */
 @specifiedBy("https://example.com/specifiedBy/uuid")
+@gql.annotate({
+  name: "scalarMetadata",
+  args: {config: {label: "deferred"}, tier: Premium},
+})
 @gql.annotate({name: "tag", args: {name: "scalar"}})
 @gql.scalar
 type uuid = string

--- a/tests/src/AppDirectives.res
+++ b/tests/src/AppDirectives.res
@@ -9,6 +9,12 @@ type cacheControl = {
   legacyScope: option<string>,
 }
 
+@gql.directive({locations: ["OBJECT"]})
+type identifies = {
+  @gql.default(123)
+  value: ResGraph.id,
+}
+
 /** Repeatable labels for schema elements. */
 @gql.directive({
   locations: [
@@ -36,6 +42,7 @@ type directiveInput = {
 type directiveStatus =
   | @gql.annotate({name: "tag", args: {name: "enum-value"}}) Active
 
+@gql.annotate({name: "identifies", args: {value: 456}})
 @gql.annotate({name: "tag", args: {name: "first"}})
 @gql.annotate({name: "cacheControl", args: {maxAge: 30}})
 @gql.annotate({name: "tag", args: {name: "second"}})

--- a/tests/src/AppDirectives.res
+++ b/tests/src/AppDirectives.res
@@ -1,0 +1,56 @@
+/** Caching metadata consumed by an explicit schema transform. */
+@gql.directive({locations: ["OBJECT", "FIELD_DEFINITION"], repeatable: false})
+type cacheControl = {
+  /** Maximum cache lifetime in seconds. */
+  @gql.default(60)
+  maxAge: int,
+  scope: option<string>,
+  @deprecated("Use scope instead.")
+  legacyScope: option<string>,
+}
+
+/** Repeatable labels for schema elements. */
+@gql.directive({
+  locations: [
+    "SCALAR",
+    "OBJECT",
+    "FIELD_DEFINITION",
+    "ENUM",
+    "ENUM_VALUE",
+    "INPUT_OBJECT",
+    "INPUT_FIELD_DEFINITION",
+  ],
+  repeatable: true,
+})
+type tag = {name: string}
+
+@gql.annotate({name: "tag", args: {name: "input"}})
+@gql.inputObject
+type directiveInput = {
+  @gql.annotate({name: "tag", args: {name: "input-field"}})
+  value: string,
+}
+
+@gql.annotate({name: "tag", args: {name: "enum"}})
+@gql.enum
+type directiveStatus =
+  | @gql.annotate({name: "tag", args: {name: "enum-value"}}) Active
+
+@gql.annotate({name: "tag", args: {name: "first"}})
+@gql.annotate({name: "cacheControl", args: {maxAge: 30}})
+@gql.annotate({name: "tag", args: {name: "second"}})
+@gql.type
+type directiveExample = {
+  @gql.annotate({name: "cacheControl", args: {maxAge: 10, scope: "private"}})
+  @gql.annotate({name: "tag", args: {name: "field"}})
+  @gql.field
+  value: string,
+  @gql.field
+  status: directiveStatus,
+}
+
+@gql.field
+let directiveExample = (_: Query.query, ~input: directiveInput): directiveExample => {
+  value: input.value,
+  status: Active,
+}

--- a/tests/src/AppDirectives.res
+++ b/tests/src/AppDirectives.res
@@ -1,11 +1,11 @@
-/** Caching metadata consumed by an explicit schema transform. */
+/** Caching metadata consumed by a """schema transform""". */
 @gql.directive({locations: ["OBJECT", "FIELD_DEFINITION"], repeatable: false})
 type cacheControl = {
   /** Maximum cache lifetime in seconds. */
   @gql.default(60)
   maxAge: int,
   scope: option<string>,
-  @deprecated("Use scope instead.")
+  @deprecated("Use \"scope\" instead.")
   legacyScope: option<string>,
 }
 

--- a/tests/src/__generated__/ResGraphSchema.res
+++ b/tests/src/__generated__/ResGraphSchema.res
@@ -1464,7 +1464,7 @@ inputUnion_UpdatableString.contents = GraphQLInputObjectType.make({
 
 let directive_cacheControl = GraphQLDirective.make({
   name: "cacheControl",
-  description: "Caching metadata consumed by an explicit schema transform.",
+  description: "Caching metadata consumed by a \u0022\u0022\u0022schema transform\u0022\u0022\u0022.",
   locations: ["OBJECT", "FIELD_DEFINITION"],
   args: dict{
     "maxAge": ({
@@ -1481,7 +1481,7 @@ let directive_cacheControl = GraphQLDirective.make({
     "legacyScope": ({
       typ: Scalars.string->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: "Use scope instead.",
+      deprecationReason: "Use \"scope\" instead.",
     }: arg)
   }->makeArgsDict,
   isRepeatable: false

--- a/tests/src/__generated__/ResGraphSchema.res
+++ b/tests/src/__generated__/ResGraphSchema.res
@@ -86,14 +86,14 @@ let applyConversionToInputObject: ('a, array<(string, inputObjectFieldConverterF
   return newObj;
 }`)
 
-let scalar_Uuid = GraphQLScalar.make({name: "Uuid", description: "Custom scalar with specifiedByUrl coverage.", specifiedByURL: "https://example.com/specifiedBy/uuid", extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("scalar")}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("scalar")}}]}}})
+let scalar_Uuid = GraphQLScalar.make({name: "Uuid", description: "Custom scalar with specifiedByUrl coverage.", specifiedByURL: "https://example.com/specifiedBy/uuid", extensions: {directives: dict{"tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("scalar"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("scalar"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}}})
 
 let enum_DirectiveStatus = GraphQLEnumType.make({
   name: "DirectiveStatus",
   description: ?(None),
-  extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("enum")}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("enum")}}]}},
+  extensions: {directives: dict{"tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}},
   values: {
-    "Active": {GraphQLEnumType.value: "Active", description: ?(None), deprecationReason: ?(None), extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("enum-value")}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("enum-value")}}]}}},
+    "Active": {GraphQLEnumType.value: "Active", description: ?(None), deprecationReason: ?(None), extensions: {directives: dict{"tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum-value"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum-value"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}}},
   }->makeEnumValues,
 })
 
@@ -515,7 +515,7 @@ t_DirectiveExample.contents = GraphQLObjectType.make({
   name: "DirectiveExample",
   description: ?(None),
   interfaces: [],
-  extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("first")}, dict{"name": GraphQLLiteralValue.String("second")}], "cacheControl": [dict{"maxAge": GraphQLLiteralValue.Number(30.)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("first")}}, {name: "cacheControl", args: dict{"maxAge": GraphQLLiteralValue.Number(30.)}}, {name: "tag", args: dict{"name": GraphQLLiteralValue.String("second")}}]}},
+  extensions: {directives: dict{"identifies": [dict{"value": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(456.), Scalars.id->Scalars.toGraphQLType->nonNull)}], "tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("first"), Scalars.string->Scalars.toGraphQLType->nonNull)}, dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("second"), Scalars.string->Scalars.toGraphQLType->nonNull)}], "cacheControl": [dict{"maxAge": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(30.), Scalars.int->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "identifies", args: dict{"value": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(456.), Scalars.id->Scalars.toGraphQLType->nonNull)}}, {name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("first"), Scalars.string->Scalars.toGraphQLType->nonNull)}}, {name: "cacheControl", args: dict{"maxAge": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(30.), Scalars.int->Scalars.toGraphQLType->nonNull)}}, {name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("second"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}},
   fields: () => {
     "status": {
       typ: enum_DirectiveStatus->GraphQLEnumType.toGraphQLType->nonNull,
@@ -527,7 +527,7 @@ t_DirectiveExample.contents = GraphQLObjectType.make({
       typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
-      extensions: {directives: dict{"cacheControl": [dict{"maxAge": GraphQLLiteralValue.Number(10.), "scope": GraphQLLiteralValue.String("private")}], "tag": [dict{"name": GraphQLLiteralValue.String("field")}]}, resgraph: {appliedDirectives: [{name: "cacheControl", args: dict{"maxAge": GraphQLLiteralValue.Number(10.), "scope": GraphQLLiteralValue.String("private")}}, {name: "tag", args: dict{"name": GraphQLLiteralValue.String("field")}}]}},
+      extensions: {directives: dict{"cacheControl": [dict{"maxAge": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(10.), Scalars.int->Scalars.toGraphQLType->nonNull), "scope": GraphQLInput.coerceValue(GraphQLLiteralValue.String("private"), Scalars.string->Scalars.toGraphQLType)}], "tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("field"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "cacheControl", args: dict{"maxAge": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(10.), Scalars.int->Scalars.toGraphQLType->nonNull), "scope": GraphQLInput.coerceValue(GraphQLLiteralValue.String("private"), Scalars.string->Scalars.toGraphQLType)}}, {name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("field"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}},
       resolve: makeResolveFn((src, _args, _ctx, _info) => {let src = typeUnwrapper(src); src["value"]})
     }
   }->makeFields
@@ -1236,10 +1236,10 @@ input_DirectiveInput.contents = GraphQLInputObjectType.make({
       GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
-      extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("input-field")}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("input-field")}}]}}
+      extensions: {directives: dict{"tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("input-field"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("input-field"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}}
     }
   }->makeFields,
-  extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("input")}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("input")}}]}}
+  extensions: {directives: dict{"tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("input"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("input"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}}
 })
 input_ReservedWordInput.contents = GraphQLInputObjectType.make({
   name: "ReservedWordInput",
@@ -1469,7 +1469,7 @@ let directive_cacheControl = GraphQLDirective.make({
   args: dict{
     "maxAge": ({
       typ: Scalars.int->Scalars.toGraphQLType->nonNull,
-      defaultValue: GraphQLLiteralValue.Number(60.),
+      defaultValue: GraphQLInput.coerceValue(GraphQLLiteralValue.Number(60.), Scalars.int->Scalars.toGraphQLType->nonNull),
       description: "Maximum cache lifetime in seconds.",
       deprecationReason: ?(None),
     }: arg),
@@ -1482,6 +1482,20 @@ let directive_cacheControl = GraphQLDirective.make({
       typ: Scalars.string->Scalars.toGraphQLType,
       description: ?(None),
       deprecationReason: "Use \"scope\" instead.",
+    }: arg)
+  }->makeArgsDict,
+  isRepeatable: false
+})
+let directive_identifies = GraphQLDirective.make({
+  name: "identifies",
+  description: ?(None),
+  locations: ["OBJECT"],
+  args: dict{
+    "value": ({
+      typ: Scalars.id->Scalars.toGraphQLType->nonNull,
+      defaultValue: GraphQLInput.coerceValue(GraphQLLiteralValue.Number(123.), Scalars.id->Scalars.toGraphQLType->nonNull),
+      description: ?(None),
+      deprecationReason: ?(None),
     }: arg)
   }->makeArgsDict,
   isRepeatable: false
@@ -1504,7 +1518,7 @@ let schema = GraphQLSchemaType.makeConfig({
   query: get_Query(),
   mutation: get_Mutation(),
   subscription: get_Subscription(),
-  directives: [...GraphQLDirective.specifiedDirectives, directive_cacheControl, directive_tag],
+  directives: [...GraphQLDirective.specifiedDirectives, directive_cacheControl, directive_identifies, directive_tag],
   types: [
     get_DirectiveExample()->GraphQLObjectType.toGraphQLType,
     get_ExplicitCompany()->GraphQLObjectType.toGraphQLType,

--- a/tests/src/__generated__/ResGraphSchema.res
+++ b/tests/src/__generated__/ResGraphSchema.res
@@ -86,16 +86,12 @@ let applyConversionToInputObject: ('a, array<(string, inputObjectFieldConverterF
   return newObj;
 }`)
 
-let scalar_Uuid = GraphQLScalar.make({name: "Uuid", description: "Custom scalar with specifiedByUrl coverage.", specifiedByURL: "https://example.com/specifiedBy/uuid", extensions: {directives: dict{"tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("scalar"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("scalar"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}}})
-
-let enum_DirectiveStatus = GraphQLEnumType.make({
-  name: "DirectiveStatus",
-  description: ?(None),
-  extensions: {directives: dict{"tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}},
-  values: {
-    "Active": {GraphQLEnumType.value: "Active", description: ?(None), deprecationReason: ?(None), extensions: {directives: dict{"tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum-value"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum-value"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}}},
-  }->makeEnumValues,
-})
+let scalar_Uuid: ref<GraphQLScalar.t> = Obj.magic({"contents": null})
+let getScalar_Uuid = () => scalar_Uuid.contents
+let enum_DirectiveStatus: ref<GraphQLEnumType.t> = Obj.magic({"contents": null})
+let getEnum_DirectiveStatus = () => enum_DirectiveStatus.contents
+let enum_ScalarTier: ref<GraphQLEnumType.t> = Obj.magic({"contents": null})
+let getEnum_ScalarTier = () => enum_ScalarTier.contents
 
 let i_CompanyHolder: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
 let get_CompanyHolder = () => i_CompanyHolder.contents
@@ -203,12 +199,16 @@ let input_DirectiveInput_conversionInstructions = []
 let input_ReservedWordInput: ref<GraphQLInputObjectType.t> = Obj.magic({"contents": null})
 let get_ReservedWordInput = () => input_ReservedWordInput.contents
 let input_ReservedWordInput_conversionInstructions = []
+let input_ScalarMetadataInput: ref<GraphQLInputObjectType.t> = Obj.magic({"contents": null})
+let get_ScalarMetadataInput = () => input_ScalarMetadataInput.contents
+let input_ScalarMetadataInput_conversionInstructions = []
 let input_UpdateThingInput: ref<GraphQLInputObjectType.t> = Obj.magic({"contents": null})
 let get_UpdateThingInput = () => input_UpdateThingInput.contents
 let input_UpdateThingInput_conversionInstructions = []
 input_Res12InputInline_conversionInstructions->Array.pushMany([])
 input_DirectiveInput_conversionInstructions->Array.pushMany([])
 input_ReservedWordInput_conversionInstructions->Array.pushMany([])
+input_ScalarMetadataInput_conversionInstructions->Array.pushMany([])
 input_UpdateThingInput_conversionInstructions->Array.pushMany([
   (
     "name",
@@ -337,6 +337,25 @@ inputUnion_UpdatableString_conversionInstructions->Array.pushMany([
     makeInputObjectFieldConverterFn((v) => (v->Nullable.toOption))
   ),
 ])
+
+scalar_Uuid.contents = GraphQLScalar.make({name: "Uuid", description: "Custom scalar with specifiedByUrl coverage.", specifiedByURL: "https://example.com/specifiedBy/uuid", extensions: {directives: dict{"scalarMetadata": [makeLazyDirectiveArguments(dict{"config": () => GraphQLInput.coerceValue(GraphQLLiteralValue.Object(dict{"label": GraphQLLiteralValue.String("deferred")}), get_ScalarMetadataInput()->GraphQLInputObjectType.toGraphQLType->nonNull), "tier": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("Premium"), getEnum_ScalarTier()->GraphQLEnumType.toGraphQLType->nonNull)})], "tag": [makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("scalar"), Scalars.string->Scalars.toGraphQLType->nonNull)})]}, resgraph: {appliedDirectives: [{name: "scalarMetadata", args: makeLazyDirectiveArguments(dict{"config": () => GraphQLInput.coerceValue(GraphQLLiteralValue.Object(dict{"label": GraphQLLiteralValue.String("deferred")}), get_ScalarMetadataInput()->GraphQLInputObjectType.toGraphQLType->nonNull), "tier": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("Premium"), getEnum_ScalarTier()->GraphQLEnumType.toGraphQLType->nonNull)})}, {name: "tag", args: makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("scalar"), Scalars.string->Scalars.toGraphQLType->nonNull)})}]}}})
+
+enum_DirectiveStatus.contents = GraphQLEnumType.make({
+  name: "DirectiveStatus",
+  description: ?(None),
+  extensions: {directives: dict{"tag": [makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum"), Scalars.string->Scalars.toGraphQLType->nonNull)})]}, resgraph: {appliedDirectives: [{name: "tag", args: makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum"), Scalars.string->Scalars.toGraphQLType->nonNull)})}]}},
+  values: {
+    "Active": {GraphQLEnumType.value: "Active", description: ?(None), deprecationReason: ?(None), extensions: {directives: dict{"tag": [makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum-value"), Scalars.string->Scalars.toGraphQLType->nonNull)})]}, resgraph: {appliedDirectives: [{name: "tag", args: makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("enum-value"), Scalars.string->Scalars.toGraphQLType->nonNull)})}]}}},
+  }->makeEnumValues,
+})
+
+enum_ScalarTier.contents = GraphQLEnumType.make({
+  name: "ScalarTier",
+  description: ?(None),
+  values: {
+    "Premium": {GraphQLEnumType.value: "Premium", description: ?(None), deprecationReason: ?(None)},
+  }->makeEnumValues,
+})
 
 let interface_CompanyHolder_resolveType = (v: Interface_companyHolder.Resolver.t) => resolveInterfaceTypename(v, ["ExplicitCompanyHolder"], "CompanyHolder", "Interface_companyHolder.Resolver.t")
 
@@ -515,10 +534,10 @@ t_DirectiveExample.contents = GraphQLObjectType.make({
   name: "DirectiveExample",
   description: ?(None),
   interfaces: [],
-  extensions: {directives: dict{"identifies": [dict{"value": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(456.), Scalars.id->Scalars.toGraphQLType->nonNull)}], "tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("first"), Scalars.string->Scalars.toGraphQLType->nonNull)}, dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("second"), Scalars.string->Scalars.toGraphQLType->nonNull)}], "cacheControl": [dict{"maxAge": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(30.), Scalars.int->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "identifies", args: dict{"value": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(456.), Scalars.id->Scalars.toGraphQLType->nonNull)}}, {name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("first"), Scalars.string->Scalars.toGraphQLType->nonNull)}}, {name: "cacheControl", args: dict{"maxAge": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(30.), Scalars.int->Scalars.toGraphQLType->nonNull)}}, {name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("second"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}},
+  extensions: {directives: dict{"identifies": [makeLazyDirectiveArguments(dict{"value": () => GraphQLInput.coerceValue(GraphQLLiteralValue.Number(456.), Scalars.id->Scalars.toGraphQLType->nonNull)})], "tag": [makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("first"), Scalars.string->Scalars.toGraphQLType->nonNull)}), makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("second"), Scalars.string->Scalars.toGraphQLType->nonNull)})], "cacheControl": [makeLazyDirectiveArguments(dict{"maxAge": () => GraphQLInput.coerceValue(GraphQLLiteralValue.Number(30.), Scalars.int->Scalars.toGraphQLType->nonNull)})]}, resgraph: {appliedDirectives: [{name: "identifies", args: makeLazyDirectiveArguments(dict{"value": () => GraphQLInput.coerceValue(GraphQLLiteralValue.Number(456.), Scalars.id->Scalars.toGraphQLType->nonNull)})}, {name: "tag", args: makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("first"), Scalars.string->Scalars.toGraphQLType->nonNull)})}, {name: "cacheControl", args: makeLazyDirectiveArguments(dict{"maxAge": () => GraphQLInput.coerceValue(GraphQLLiteralValue.Number(30.), Scalars.int->Scalars.toGraphQLType->nonNull)})}, {name: "tag", args: makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("second"), Scalars.string->Scalars.toGraphQLType->nonNull)})}]}},
   fields: () => {
     "status": {
-      typ: enum_DirectiveStatus->GraphQLEnumType.toGraphQLType->nonNull,
+      typ: getEnum_DirectiveStatus()->GraphQLEnumType.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
       resolve: makeResolveFn((src, _args, _ctx, _info) => {let src = typeUnwrapper(src); src["status"]})
@@ -527,7 +546,7 @@ t_DirectiveExample.contents = GraphQLObjectType.make({
       typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
-      extensions: {directives: dict{"cacheControl": [dict{"maxAge": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(10.), Scalars.int->Scalars.toGraphQLType->nonNull), "scope": GraphQLInput.coerceValue(GraphQLLiteralValue.String("private"), Scalars.string->Scalars.toGraphQLType)}], "tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("field"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "cacheControl", args: dict{"maxAge": GraphQLInput.coerceValue(GraphQLLiteralValue.Number(10.), Scalars.int->Scalars.toGraphQLType->nonNull), "scope": GraphQLInput.coerceValue(GraphQLLiteralValue.String("private"), Scalars.string->Scalars.toGraphQLType)}}, {name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("field"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}},
+      extensions: {directives: dict{"cacheControl": [makeLazyDirectiveArguments(dict{"maxAge": () => GraphQLInput.coerceValue(GraphQLLiteralValue.Number(10.), Scalars.int->Scalars.toGraphQLType->nonNull), "scope": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("private"), Scalars.string->Scalars.toGraphQLType)})], "tag": [makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("field"), Scalars.string->Scalars.toGraphQLType->nonNull)})]}, resgraph: {appliedDirectives: [{name: "cacheControl", args: makeLazyDirectiveArguments(dict{"maxAge": () => GraphQLInput.coerceValue(GraphQLLiteralValue.Number(10.), Scalars.int->Scalars.toGraphQLType->nonNull), "scope": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("private"), Scalars.string->Scalars.toGraphQLType)})}, {name: "tag", args: makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("field"), Scalars.string->Scalars.toGraphQLType->nonNull)})}]}},
       resolve: makeResolveFn((src, _args, _ctx, _info) => {let src = typeUnwrapper(src); src["value"]})
     }
   }->makeFields
@@ -1033,7 +1052,7 @@ t_ScalarHolder.contents = GraphQLObjectType.make({
   interfaces: [],
   fields: () => {
     "id": {
-      typ: scalar_Uuid->GraphQLScalar.toGraphQLType->nonNull,
+      typ: getScalar_Uuid()->GraphQLScalar.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
       resolve: makeResolveFn((src, _args, _ctx, _info) => {let src = typeUnwrapper(src); src["id"]})
@@ -1236,10 +1255,10 @@ input_DirectiveInput.contents = GraphQLInputObjectType.make({
       GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
-      extensions: {directives: dict{"tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("input-field"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("input-field"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}}
+      extensions: {directives: dict{"tag": [makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("input-field"), Scalars.string->Scalars.toGraphQLType->nonNull)})]}, resgraph: {appliedDirectives: [{name: "tag", args: makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("input-field"), Scalars.string->Scalars.toGraphQLType->nonNull)})}]}}
     }
   }->makeFields,
-  extensions: {directives: dict{"tag": [dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("input"), Scalars.string->Scalars.toGraphQLType->nonNull)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLInput.coerceValue(GraphQLLiteralValue.String("input"), Scalars.string->Scalars.toGraphQLType->nonNull)}}]}}
+  extensions: {directives: dict{"tag": [makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("input"), Scalars.string->Scalars.toGraphQLType->nonNull)})]}, resgraph: {appliedDirectives: [{name: "tag", args: makeLazyDirectiveArguments(dict{"name": () => GraphQLInput.coerceValue(GraphQLLiteralValue.String("input"), Scalars.string->Scalars.toGraphQLType->nonNull)})}]}}
 })
 input_ReservedWordInput.contents = GraphQLInputObjectType.make({
   name: "ReservedWordInput",
@@ -1251,6 +1270,17 @@ input_ReservedWordInput.contents = GraphQLInputObjectType.make({
       deprecationReason: ?(None),
     },
     "type": {
+      GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+      description: ?(None),
+      deprecationReason: ?(None),
+    }
+  }->makeFields
+})
+input_ScalarMetadataInput.contents = GraphQLInputObjectType.make({
+  name: "ScalarMetadataInput",
+  description: ?(None),
+  fields: () => {
+    "label": {
       GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
@@ -1500,6 +1530,24 @@ let directive_identifies = GraphQLDirective.make({
   }->makeArgsDict,
   isRepeatable: false
 })
+let directive_scalarMetadata = GraphQLDirective.make({
+  name: "scalarMetadata",
+  description: ?(None),
+  locations: ["SCALAR"],
+  args: dict{
+    "config": ({
+      typ: get_ScalarMetadataInput()->GraphQLInputObjectType.toGraphQLType->nonNull,
+      description: ?(None),
+      deprecationReason: ?(None),
+    }: arg),
+    "tier": ({
+      typ: getEnum_ScalarTier()->GraphQLEnumType.toGraphQLType->nonNull,
+      description: ?(None),
+      deprecationReason: ?(None),
+    }: arg)
+  }->makeArgsDict,
+  isRepeatable: false
+})
 let directive_tag = GraphQLDirective.make({
   name: "tag",
   description: "Repeatable labels for schema elements.",
@@ -1518,7 +1566,7 @@ let schema = GraphQLSchemaType.makeConfig({
   query: get_Query(),
   mutation: get_Mutation(),
   subscription: get_Subscription(),
-  directives: [...GraphQLDirective.specifiedDirectives, directive_cacheControl, directive_identifies, directive_tag],
+  directives: [...GraphQLDirective.specifiedDirectives, directive_cacheControl, directive_identifies, directive_scalarMetadata, directive_tag],
   types: [
     get_DirectiveExample()->GraphQLObjectType.toGraphQLType,
     get_ExplicitCompany()->GraphQLObjectType.toGraphQLType,
@@ -1567,7 +1615,9 @@ let schema = GraphQLSchemaType.makeConfig({
     get_Res12InputInline()->GraphQLInputObjectType.toGraphQLType,
     get_DirectiveInput()->GraphQLInputObjectType.toGraphQLType,
     get_ReservedWordInput()->GraphQLInputObjectType.toGraphQLType,
+    get_ScalarMetadataInput()->GraphQLInputObjectType.toGraphQLType,
     get_UpdateThingInput()->GraphQLInputObjectType.toGraphQLType,
-    enum_DirectiveStatus->GraphQLEnumType.toGraphQLType
+    getEnum_DirectiveStatus()->GraphQLEnumType.toGraphQLType,
+    getEnum_ScalarTier()->GraphQLEnumType.toGraphQLType
   ]
 })

--- a/tests/src/__generated__/ResGraphSchema.res
+++ b/tests/src/__generated__/ResGraphSchema.res
@@ -86,7 +86,16 @@ let applyConversionToInputObject: ('a, array<(string, inputObjectFieldConverterF
   return newObj;
 }`)
 
-let scalar_Uuid = GraphQLScalar.make({name: "Uuid", description: "Custom scalar with specifiedByUrl coverage."})
+let scalar_Uuid = GraphQLScalar.make({name: "Uuid", description: "Custom scalar with specifiedByUrl coverage.", specifiedByURL: "https://example.com/specifiedBy/uuid", extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("scalar")}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("scalar")}}]}}})
+
+let enum_DirectiveStatus = GraphQLEnumType.make({
+  name: "DirectiveStatus",
+  description: ?(None),
+  extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("enum")}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("enum")}}]}},
+  values: {
+    "Active": {GraphQLEnumType.value: "Active", description: ?(None), deprecationReason: ?(None), extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("enum-value")}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("enum-value")}}]}}},
+  }->makeEnumValues,
+})
 
 let i_CompanyHolder: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
 let get_CompanyHolder = () => i_CompanyHolder.contents
@@ -108,6 +117,8 @@ let i_Ranked: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
 let get_Ranked = () => i_Ranked.contents
 let i_Searchable: ref<GraphQLInterfaceType.t> = Obj.magic({"contents": null})
 let get_Searchable = () => i_Searchable.contents
+let t_DirectiveExample: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
+let get_DirectiveExample = () => t_DirectiveExample.contents
 let t_ExplicitCompany: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
 let get_ExplicitCompany = () => t_ExplicitCompany.contents
 let t_ExplicitCompanyHolder: ref<GraphQLObjectType.t> = Obj.magic({"contents": null})
@@ -186,6 +197,9 @@ let inputUnion_UpdatableString_conversionInstructions = []
 let input_Res12InputInline: ref<GraphQLInputObjectType.t> = Obj.magic({"contents": null})
 let get_Res12InputInline = () => input_Res12InputInline.contents
 let input_Res12InputInline_conversionInstructions = []
+let input_DirectiveInput: ref<GraphQLInputObjectType.t> = Obj.magic({"contents": null})
+let get_DirectiveInput = () => input_DirectiveInput.contents
+let input_DirectiveInput_conversionInstructions = []
 let input_ReservedWordInput: ref<GraphQLInputObjectType.t> = Obj.magic({"contents": null})
 let get_ReservedWordInput = () => input_ReservedWordInput.contents
 let input_ReservedWordInput_conversionInstructions = []
@@ -193,6 +207,7 @@ let input_UpdateThingInput: ref<GraphQLInputObjectType.t> = Obj.magic({"contents
 let get_UpdateThingInput = () => input_UpdateThingInput.contents
 let input_UpdateThingInput_conversionInstructions = []
 input_Res12InputInline_conversionInstructions->Array.pushMany([])
+input_DirectiveInput_conversionInstructions->Array.pushMany([])
 input_ReservedWordInput_conversionInstructions->Array.pushMany([])
 input_UpdateThingInput_conversionInstructions->Array.pushMany([
   (
@@ -489,12 +504,33 @@ i_Searchable.contents = GraphQLInterfaceType.make({
       typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
-      args: {
-        "prefix": {typ: Scalars.string->Scalars.toGraphQLType}
-      }->makeArgs,
+      args: dict{
+        "prefix": ({typ: Scalars.string->Scalars.toGraphQLType}: arg)
+      }->makeArgsDict,
     }
   }->makeFields,
   resolveType: GraphQLInterfaceType.makeResolveInterfaceTypeFn(interface_Searchable_resolveType)
+})
+t_DirectiveExample.contents = GraphQLObjectType.make({
+  name: "DirectiveExample",
+  description: ?(None),
+  interfaces: [],
+  extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("first")}, dict{"name": GraphQLLiteralValue.String("second")}], "cacheControl": [dict{"maxAge": GraphQLLiteralValue.Number(30.)}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("first")}}, {name: "cacheControl", args: dict{"maxAge": GraphQLLiteralValue.Number(30.)}}, {name: "tag", args: dict{"name": GraphQLLiteralValue.String("second")}}]}},
+  fields: () => {
+    "status": {
+      typ: enum_DirectiveStatus->GraphQLEnumType.toGraphQLType->nonNull,
+      description: ?(None),
+      deprecationReason: ?(None),
+      resolve: makeResolveFn((src, _args, _ctx, _info) => {let src = typeUnwrapper(src); src["status"]})
+    },
+    "value": {
+      typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+      description: ?(None),
+      deprecationReason: ?(None),
+      extensions: {directives: dict{"cacheControl": [dict{"maxAge": GraphQLLiteralValue.Number(10.), "scope": GraphQLLiteralValue.String("private")}], "tag": [dict{"name": GraphQLLiteralValue.String("field")}]}, resgraph: {appliedDirectives: [{name: "cacheControl", args: dict{"maxAge": GraphQLLiteralValue.Number(10.), "scope": GraphQLLiteralValue.String("private")}}, {name: "tag", args: dict{"name": GraphQLLiteralValue.String("field")}}]}},
+      resolve: makeResolveFn((src, _args, _ctx, _info) => {let src = typeUnwrapper(src); src["value"]})
+    }
+  }->makeFields
 })
 t_ExplicitCompany.contents = GraphQLObjectType.make({
   name: "ExplicitCompany",
@@ -599,9 +635,9 @@ t_ExplicitSearchResult.contents = GraphQLObjectType.make({
       typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
-      args: {
-        "prefix": {typ: Scalars.string->Scalars.toGraphQLType}
-      }->makeArgs,
+      args: dict{
+        "prefix": ({typ: Scalars.string->Scalars.toGraphQLType}: arg)
+      }->makeArgsDict,
       resolve: makeResolveFn((src, args, ctx, info) => {let src = typeUnwrapper(src); AppExplicitInterfaceImplements.label(src, ~prefix=?((args["prefix"]->Nullable.toOption)))})
     }
   }->makeFields
@@ -685,10 +721,10 @@ t_Mutation.contents = GraphQLObjectType.make({
       typ: get_Thing()->GraphQLObjectType.toGraphQLType,
       description: ?(None),
       deprecationReason: ?(None),
-      args: {
-        "input": {typ: get_UpdateThingInput()->GraphQLInputObjectType.toGraphQLType->nonNull},
-        "thingId": {typ: Scalars.id->Scalars.toGraphQLType->nonNull}
-      }->makeArgs,
+      args: dict{
+        "input": ({typ: get_UpdateThingInput()->GraphQLInputObjectType.toGraphQLType->nonNull}: arg),
+        "thingId": ({typ: Scalars.id->Scalars.toGraphQLType->nonNull}: arg)
+      }->makeArgsDict,
       resolve: makeResolveFn((src, args, ctx, info) => {let src = typeUnwrapper(src); Thing.updateThing(src, ~input=args["input"]->applyConversionToInputObject(input_UpdateThingInput_conversionInstructions), ~thingId=args["thingId"])})
     }
   }->makeFields
@@ -759,6 +795,15 @@ t_Query.contents = GraphQLObjectType.make({
       description: ?(None),
       deprecationReason: ?(None),
       resolve: makeResolveFn((src, args, ctx, info) => {let src = typeUnwrapper(src); AppInterfaceReturnRegression.brokenLabelledWrapper(src)})
+    },
+    "directiveExample": {
+      typ: get_DirectiveExample()->GraphQLObjectType.toGraphQLType->nonNull,
+      description: ?(None),
+      deprecationReason: ?(None),
+      args: dict{
+        "input": ({typ: get_DirectiveInput()->GraphQLInputObjectType.toGraphQLType->nonNull}: arg)
+      }->makeArgsDict,
+      resolve: makeResolveFn((src, args, ctx, info) => {let src = typeUnwrapper(src); AppDirectives.directiveExample(src, ~input=args["input"]->applyConversionToInputObject(input_DirectiveInput_conversionInstructions))})
     },
     "explicitCompany": {
       typ: get_ExplicitCompany()->GraphQLObjectType.toGraphQLType->nonNull,
@@ -842,46 +887,46 @@ t_Query.contents = GraphQLObjectType.make({
       typ: get_Node()->GraphQLInterfaceType.toGraphQLType,
       description: "Fetches an object given its ID.",
       deprecationReason: ?(None),
-      args: {
-        "id": {typ: Scalars.id->Scalars.toGraphQLType->nonNull}
-      }->makeArgs,
+      args: dict{
+        "id": ({typ: Scalars.id->Scalars.toGraphQLType->nonNull}: arg)
+      }->makeArgsDict,
       resolve: makeResolveFn((src, args, ctx, info) => {let src = typeUnwrapper(src); NodeInterfaceResolver.node(src, ~ctx=ctx, ~id=args["id"])})
     },
     "nodes": {
       typ: GraphQLListType.make(get_Node()->GraphQLInterfaceType.toGraphQLType)->GraphQLListType.toGraphQLType->nonNull,
       description: "Fetches objects given their IDs.",
       deprecationReason: ?(None),
-      args: {
-        "ids": {typ: GraphQLListType.make(Scalars.id->Scalars.toGraphQLType->nonNull)->GraphQLListType.toGraphQLType->nonNull}
-      }->makeArgs,
+      args: dict{
+        "ids": ({typ: GraphQLListType.make(Scalars.id->Scalars.toGraphQLType->nonNull)->GraphQLListType.toGraphQLType->nonNull}: arg)
+      }->makeArgsDict,
       resolve: makeResolveFn((src, args, ctx, info) => {let src = typeUnwrapper(src); NodeInterfaceResolver.nodes(src, ~ctx=ctx, ~ids=args["ids"])})
     },
     "nullableInterop": {
       typ: get_NullableInterop()->GraphQLObjectType.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
-      args: {
-        "nullCount": {typ: Scalars.int->Scalars.toGraphQLType},
-        "nullableName": {typ: Scalars.string->Scalars.toGraphQLType}
-      }->makeArgs,
+      args: dict{
+        "nullCount": ({typ: Scalars.int->Scalars.toGraphQLType}: arg),
+        "nullableName": ({typ: Scalars.string->Scalars.toGraphQLType}: arg)
+      }->makeArgsDict,
       resolve: makeResolveFn((src, args, ctx, info) => {let src = typeUnwrapper(src); AppNullableInterop.nullableInterop(src, ~nullCount=args["nullCount"], ~nullableName=args["nullableName"])})
     },
     "reservedWordArgumentEcho": {
       typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
-      args: {
-        "constraint": {typ: Scalars.string->Scalars.toGraphQLType->nonNull}
-      }->makeArgs,
+      args: dict{
+        "constraint": ({typ: Scalars.string->Scalars.toGraphQLType->nonNull}: arg)
+      }->makeArgsDict,
       resolve: makeResolveFn((src, args, ctx, info) => {let src = typeUnwrapper(src); AppReScript12.reservedWordArgumentEcho(src, ~\"constraint"=args["constraint"])})
     },
     "reservedWordInputEcho": {
       typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
-      args: {
-        "input": {typ: get_ReservedWordInput()->GraphQLInputObjectType.toGraphQLType->nonNull}
-      }->makeArgs,
+      args: dict{
+        "input": ({typ: get_ReservedWordInput()->GraphQLInputObjectType.toGraphQLType->nonNull}: arg)
+      }->makeArgsDict,
       resolve: makeResolveFn((src, args, ctx, info) => {let src = typeUnwrapper(src); AppReScript12.reservedWordInputEcho(src, ~input=args["input"]->applyConversionToInputObject(input_ReservedWordInput_conversionInstructions))})
     },
     "reservedWordRecord": {
@@ -894,10 +939,10 @@ t_Query.contents = GraphQLObjectType.make({
       typ: get_UserConnection()->GraphQLObjectType.toGraphQLType->nonNull,
       description: ?(None),
       deprecationReason: ?(None),
-      args: {
-        "after": {typ: Scalars.string->Scalars.toGraphQLType},
-        "first": {typ: Scalars.int->Scalars.toGraphQLType}
-      }->makeArgs,
+      args: dict{
+        "after": ({typ: Scalars.string->Scalars.toGraphQLType}: arg),
+        "first": ({typ: Scalars.int->Scalars.toGraphQLType}: arg)
+      }->makeArgsDict,
       resolve: makeResolveFn((src, args, ctx, info) => {let src = typeUnwrapper(src); AppConnections.userConnection(src, ~after=?((args["after"]->Nullable.toOption)), ~first=?((args["first"]->Nullable.toOption)))})
     },
     "userDefinedNullable": {
@@ -1179,9 +1224,22 @@ input_Res12InputInline.contents = GraphQLInputObjectType.make({
     "payload": {
       GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: "Field doc on inline record.",
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields
+})
+input_DirectiveInput.contents = GraphQLInputObjectType.make({
+  name: "DirectiveInput",
+  description: ?(None),
+  fields: () => {
+    "value": {
+      GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+      description: ?(None),
+      deprecationReason: ?(None),
+      extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("input-field")}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("input-field")}}]}}
+    }
+  }->makeFields,
+  extensions: {directives: dict{"tag": [dict{"name": GraphQLLiteralValue.String("input")}]}, resgraph: {appliedDirectives: [{name: "tag", args: dict{"name": GraphQLLiteralValue.String("input")}}]}}
 })
 input_ReservedWordInput.contents = GraphQLInputObjectType.make({
   name: "ReservedWordInput",
@@ -1190,12 +1248,12 @@ input_ReservedWordInput.contents = GraphQLInputObjectType.make({
     "constraint": {
       GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "type": {
       GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType->nonNull,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields
 })
@@ -1206,27 +1264,27 @@ input_UpdateThingInput.contents = GraphQLInputObjectType.make({
     "age": {
       GraphQLInputObjectType.typ: get_UpdatableInt()->GraphQLInputObjectType.toGraphQLType->nonNull,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "favoriteColor": {
       GraphQLInputObjectType.typ: get_UpdatableNullableString()->GraphQLInputObjectType.toGraphQLType->nonNull,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "height": {
       GraphQLInputObjectType.typ: get_UpdatableNullableFloat()->GraphQLInputObjectType.toGraphQLType->nonNull,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "isAdmin": {
       GraphQLInputObjectType.typ: get_UpdatableNullableBool()->GraphQLInputObjectType.toGraphQLType->nonNull,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "name": {
       GraphQLInputObjectType.typ: get_UpdatableString()->GraphQLInputObjectType.toGraphQLType->nonNull,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields
 })
@@ -1237,12 +1295,12 @@ inputUnion_Res12Input.contents = GraphQLInputObjectType.make({
     "empty": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "inline": {
       GraphQLInputObjectType.typ: get_Res12InputInline()->GraphQLInputObjectType.toGraphQLType,
       description: " Inline record doc is preserved. ",
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields,
   extensions: {oneOf: true}
@@ -1254,12 +1312,12 @@ inputUnion_UpdatableBool.contents = GraphQLInputObjectType.make({
     "leaveUnchanged": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "updateValue": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields,
   extensions: {oneOf: true}
@@ -1271,12 +1329,12 @@ inputUnion_UpdatableFloat.contents = GraphQLInputObjectType.make({
     "leaveUnchanged": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "updateValue": {
       GraphQLInputObjectType.typ: Scalars.float->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields,
   extensions: {oneOf: true}
@@ -1288,12 +1346,12 @@ inputUnion_UpdatableInt.contents = GraphQLInputObjectType.make({
     "leaveUnchanged": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "updateValue": {
       GraphQLInputObjectType.typ: Scalars.int->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields,
   extensions: {oneOf: true}
@@ -1305,17 +1363,17 @@ inputUnion_UpdatableNullableBool.contents = GraphQLInputObjectType.make({
     "leaveUnchanged": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "unsetValue": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "updateValue": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields,
   extensions: {oneOf: true}
@@ -1327,17 +1385,17 @@ inputUnion_UpdatableNullableFloat.contents = GraphQLInputObjectType.make({
     "leaveUnchanged": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "unsetValue": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "updateValue": {
       GraphQLInputObjectType.typ: Scalars.float->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields,
   extensions: {oneOf: true}
@@ -1349,17 +1407,17 @@ inputUnion_UpdatableNullableInt.contents = GraphQLInputObjectType.make({
     "leaveUnchanged": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "unsetValue": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "updateValue": {
       GraphQLInputObjectType.typ: Scalars.int->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields,
   extensions: {oneOf: true}
@@ -1371,17 +1429,17 @@ inputUnion_UpdatableNullableString.contents = GraphQLInputObjectType.make({
     "leaveUnchanged": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "unsetValue": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "updateValue": {
       GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields,
   extensions: {oneOf: true}
@@ -1393,22 +1451,62 @@ inputUnion_UpdatableString.contents = GraphQLInputObjectType.make({
     "leaveUnchanged": {
       GraphQLInputObjectType.typ: Scalars.boolean->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     },
     "updateValue": {
       GraphQLInputObjectType.typ: Scalars.string->Scalars.toGraphQLType,
       description: ?(None),
-      deprecationReason: ?(None)
+      deprecationReason: ?(None),
     }
   }->makeFields,
   extensions: {oneOf: true}
 })
 
-let schema = GraphQLSchemaType.make({
-  "query": get_Query(),
-  "mutation": get_Mutation(),
-  "subscription": get_Subscription(),
-  "types": [
+let directive_cacheControl = GraphQLDirective.make({
+  name: "cacheControl",
+  description: "Caching metadata consumed by an explicit schema transform.",
+  locations: ["OBJECT", "FIELD_DEFINITION"],
+  args: dict{
+    "maxAge": ({
+      typ: Scalars.int->Scalars.toGraphQLType->nonNull,
+      defaultValue: GraphQLLiteralValue.Number(60.),
+      description: "Maximum cache lifetime in seconds.",
+      deprecationReason: ?(None),
+    }: arg),
+    "scope": ({
+      typ: Scalars.string->Scalars.toGraphQLType,
+      description: ?(None),
+      deprecationReason: ?(None),
+    }: arg),
+    "legacyScope": ({
+      typ: Scalars.string->Scalars.toGraphQLType,
+      description: ?(None),
+      deprecationReason: "Use scope instead.",
+    }: arg)
+  }->makeArgsDict,
+  isRepeatable: false
+})
+let directive_tag = GraphQLDirective.make({
+  name: "tag",
+  description: "Repeatable labels for schema elements.",
+  locations: ["SCALAR", "OBJECT", "FIELD_DEFINITION", "ENUM", "ENUM_VALUE", "INPUT_OBJECT", "INPUT_FIELD_DEFINITION"],
+  args: dict{
+    "name": ({
+      typ: Scalars.string->Scalars.toGraphQLType->nonNull,
+      description: ?(None),
+      deprecationReason: ?(None),
+    }: arg)
+  }->makeArgsDict,
+  isRepeatable: true
+})
+
+let schema = GraphQLSchemaType.makeConfig({
+  query: get_Query(),
+  mutation: get_Mutation(),
+  subscription: get_Subscription(),
+  directives: [...GraphQLDirective.specifiedDirectives, directive_cacheControl, directive_tag],
+  types: [
+    get_DirectiveExample()->GraphQLObjectType.toGraphQLType,
     get_ExplicitCompany()->GraphQLObjectType.toGraphQLType,
     get_ExplicitCompanyHolder()->GraphQLObjectType.toGraphQLType,
     get_ExplicitContextOverrideResult()->GraphQLObjectType.toGraphQLType,
@@ -1453,7 +1551,9 @@ let schema = GraphQLSchemaType.make({
     get_UpdatableNullableString()->GraphQLInputObjectType.toGraphQLType,
     get_UpdatableString()->GraphQLInputObjectType.toGraphQLType,
     get_Res12InputInline()->GraphQLInputObjectType.toGraphQLType,
+    get_DirectiveInput()->GraphQLInputObjectType.toGraphQLType,
     get_ReservedWordInput()->GraphQLInputObjectType.toGraphQLType,
-    get_UpdateThingInput()->GraphQLInputObjectType.toGraphQLType
+    get_UpdateThingInput()->GraphQLInputObjectType.toGraphQLType,
+    enum_DirectiveStatus->GraphQLEnumType.toGraphQLType
   ]
 })

--- a/tests/src/__generated__/schema.graphql
+++ b/tests/src/__generated__/schema.graphql
@@ -7,6 +7,10 @@ directive @cacheControl(
   legacyScope: String @deprecated(reason: "Use \"scope\" instead.")
 ) on OBJECT | FIELD_DEFINITION
 
+directive @identifies(
+  value: ID! = 123
+) on OBJECT
+
 
 """Repeatable labels for schema elements."""
 directive @tag(
@@ -143,7 +147,7 @@ interface Searchable {
   id: String!
 }
 
-type DirectiveExample @tag(name: "first") @cacheControl(maxAge: 30) @tag(name: "second") {
+type DirectiveExample @identifies(value: 456) @tag(name: "first") @cacheControl(maxAge: 30) @tag(name: "second") {
   value: String! @cacheControl(maxAge: 10, scope: "private") @tag(name: "field")
   status: DirectiveStatus!
 }

--- a/tests/src/__generated__/schema.graphql
+++ b/tests/src/__generated__/schema.graphql
@@ -1,10 +1,34 @@
+"""Caching metadata consumed by an explicit schema transform."""
+directive @cacheControl(
+
+  """Maximum cache lifetime in seconds."""
+  maxAge: Int! = 60
+  scope: String
+  legacyScope: String @deprecated(reason: "Use scope instead.")
+) on OBJECT | FIELD_DEFINITION
+
+
+"""Repeatable labels for schema elements."""
+directive @tag(
+  name: String!
+) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+
 """Custom scalar with specifiedByUrl coverage."""
-scalar Uuid
+scalar Uuid @specifiedBy(url: "https://example.com/specifiedBy/uuid") @tag(name: "scalar")
+
+enum DirectiveStatus @tag(name: "enum") {
+  Active @tag(name: "enum-value")
+}
 
 input Res12InputInline {
 
   """Field doc on inline record."""
   payload: String!
+}
+
+input DirectiveInput @tag(name: "input") {
+  value: String! @tag(name: "input-field")
 }
 
 input ReservedWordInput {
@@ -119,6 +143,11 @@ interface Searchable {
   id: String!
 }
 
+type DirectiveExample @tag(name: "first") @cacheControl(maxAge: 30) @tag(name: "second") {
+  value: String! @cacheControl(maxAge: 10, scope: "private") @tag(name: "field")
+  status: DirectiveStatus!
+}
+
 type ExplicitCompany implements NamedEntity & Named & NullableNamed & Ranked {
   name: String!
   entityKind: String!
@@ -216,6 +245,7 @@ type Query {
   explicitSearchResult: ExplicitSearchResult!
   explicitCompanyHolder: ExplicitCompanyHolder!
   explicitCompany: ExplicitCompany!
+  directiveExample(input: DirectiveInput!): DirectiveExample!
   getScalarHolder: ScalarHolder!
   nestedConnection: StringConnection!
   userConnection(first: Int, after: String): UserConnection!

--- a/tests/src/__generated__/schema.graphql
+++ b/tests/src/__generated__/schema.graphql
@@ -11,6 +11,11 @@ directive @identifies(
   value: ID! = 123
 ) on OBJECT
 
+directive @scalarMetadata(
+  config: ScalarMetadataInput!
+  tier: ScalarTier!
+) on SCALAR
+
 
 """Repeatable labels for schema elements."""
 directive @tag(
@@ -19,10 +24,14 @@ directive @tag(
 
 
 """Custom scalar with specifiedByUrl coverage."""
-scalar Uuid @specifiedBy(url: "https://example.com/specifiedBy/uuid") @tag(name: "scalar")
+scalar Uuid @specifiedBy(url: "https://example.com/specifiedBy/uuid") @scalarMetadata(config: {label: "deferred"}, tier: Premium) @tag(name: "scalar")
 
 enum DirectiveStatus @tag(name: "enum") {
   Active @tag(name: "enum-value")
+}
+
+enum ScalarTier {
+  Premium
 }
 
 input Res12InputInline {
@@ -38,6 +47,10 @@ input DirectiveInput @tag(name: "input") {
 input ReservedWordInput {
   constraint: String!
   type: String!
+}
+
+input ScalarMetadataInput {
+  label: String!
 }
 
 input UpdateThingInput {

--- a/tests/src/__generated__/schema.graphql
+++ b/tests/src/__generated__/schema.graphql
@@ -1,10 +1,10 @@
-"""Caching metadata consumed by an explicit schema transform."""
+"""Caching metadata consumed by a \"""schema transform\"""."""
 directive @cacheControl(
 
   """Maximum cache lifetime in seconds."""
   maxAge: Int! = 60
   scope: String
-  legacyScope: String @deprecated(reason: "Use scope instead.")
+  legacyScope: String @deprecated(reason: "Use \"scope\" instead.")
 ) on OBJECT | FIELD_DEFINITION
 
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -271,6 +271,8 @@ printf '%b%s%b\n' "$successGreen" \
   '✅ Invalid incremental cache is rebuilt safely.' "$reset"
 
 node ./runtime-interface-returns.mjs
+node ./runtime-directives.mjs
+bash ./invalid-directives.sh
 ./invalid-interface-implements.sh
 
 ./multi-schema-test.sh


### PR DESCRIPTION
## What changed

- adds a first-class directive and GraphQL constant-value IR
- defines typed custom directives from ReScript record or abstract types
- supports ordered `@gql.annotate` applications across CMT-visible type-system locations
- validates definitions, locations, repeatability, required/unknown arguments, and constant coercion
- emits matching SDL, `GraphQLDirective` instances, GraphQL Tools metadata, and an exact ordered ResGraph projection
- lowers `@specifiedBy` to SDL and `specifiedByURL`
- adds runtime, negative-diagnostic, generated-schema, multi-schema, and documentation coverage
- records the remaining Grats and broader GraphQL capability roadmap

## Why

ResGraph previously had no general representation for directive definitions or applications. This made schema policy metadata, ecosystem transforms, scalar specification URLs, and future Federation work depend on one-off mechanisms.

The implementation treats directives as schema data. Runtime behavior remains explicit in transforms, plugins, or resolver logic.

## User impact

Users can define directives with `@gql.directive`, apply them with `@gql.annotate`, inspect them through GraphQL Tools-compatible extensions or ResGraph's ordered projection, and rely on build-time diagnostics.

## Local validation

- native OCaml build and formatter
- root ReScript/CLI build
- generated test schema compilation
- directive SDL parsing, introspection, GraphQL Tools interoperability, ordering, and execution
- invalid directive diagnostic fixtures
- interface, authorization, and multi-schema regression paths
- Docusaurus production build

CI was intentionally not run for this handoff.