### PR TITLE
Prepare 1.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.3.1
+
 - Add explicit `@gql.authorize.byAncestor({reason})` dispositions with static
   path-dominance validation, audit-manifest provenance, and no repeated runtime
   policy evaluation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resgraph",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resgraph",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
         "@glennsl/rescript-fetch": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resgraph",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Build GraphQL servers in ReScript.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump the ResGraph npm package and lockfile to 1.3.1
- promote the ancestor authorization work from Unreleased into the 1.3.1 changelog

## Validation

- opam exec --switch=5.3.0 -- make test
- opam exec --switch=5.3.0 -- make checkformat
- npm run build
- npm pack --dry-run --json (resgraph@1.3.1)