### PR TITLE
Prepare 1.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.3.2
+
 - Support `@gql.authorize.byAncestor` defaults on interface types and fields,
   including transitive interface inheritance, concrete overrides, and
   per-concrete-field path validation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resgraph",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "resgraph",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "ISC",
       "dependencies": {
         "@glennsl/rescript-fetch": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resgraph",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Build GraphQL servers in ReScript.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What changed

- bump `resgraph` package metadata from 1.3.1 to 1.3.2
- move the interface ancestor-authorization changelog entry into the 1.3.2 release section

## Included feature

1.3.2 adds `@gql.authorize.byAncestor` support for interface types and fields, with transitive inheritance, concrete overrides, and per-concrete-field path validation.

## Validation

- PR #56 passed all platform, documentation, and package checks
- Codex review on PR #56 found no major issues
- `npm ci`
- `npm pack --dry-run`