### PR TITLE
Fix npm trusted publishing runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,13 @@ jobs:
           echo "dry_run=$dry_run" >> "$GITHUB_OUTPUT"
           echo "Using npm tag '$tag' (dry-run: $dry_run)."
 
+      - name: Use Node.js for npm trusted publishing
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Publish to npm
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         env:


### PR DESCRIPTION
## What changed

Keep package build and regression tests on the minimum supported Node 20.11.0, then switch to Node 24 for the final npm trusted-publishing step.

## Why

The v1.3.4 tag build and package tests passed, but Node 20.11 ships an npm version without GitHub OIDC trusted-publishing support. npm fell back to token-style publication and the registry returned 404.

## Release recovery

After merge, dispatch the CI workflow from main with `dry_run=false`. The v1.3.4 source tag remains unchanged because this only alters release orchestration; the package source and tarball remain the tested merge commit.